### PR TITLE
fixed case of switching to a non-tracking branch in subrepo

### DIFF
--- a/system7-tests.xctestplan
+++ b/system7-tests.xctestplan
@@ -9,18 +9,7 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false,
-    "environmentVariableEntries" : [
-      {
-        "key" : "S7_CONFIG",
-        "value" : "commit.gpgsign=false"
-      },
-      {
-        "enabled" : false,
-        "key" : "S7_TRACE",
-        "value" : "1"
-      }
-    ]
+    "codeCoverage" : false
   },
   "testTargets" : [
     {

--- a/system7-tests/Utils/TestReposEnvironment.m
+++ b/system7-tests/Utils/TestReposEnvironment.m
@@ -125,9 +125,12 @@
         NSCAssert(repo, @"");
         NSCAssert(0 == exitStatus, @"");
         
-        GitRepository.testRepoConfigureOnInitBlock = ^(GitRepository * _Nonnull repo) {
-            [repo runGitCommand:@"config --local commit.gpgsign false"];
-        };
+        // nsavko: working around my local setup
+        if ([getGlobalGitConfigValue(@"commit.gpgsign") isEqualToString:@"true"]) {
+            GitRepository.testRepoConfigureOnInitBlock = ^(GitRepository * _Nonnull repo) {
+                [repo runGitCommand:@"config --local commit.gpgsign false"];
+            };
+        }
 
         NSString *tmpCloneRepoPath = [[NSTemporaryDirectory()
                                        stringByAppendingPathComponent:@"com.readdle.system7-tests.generic-template-tmp-clone"]

--- a/system7-tests/checkoutTests.m
+++ b/system7-tests/checkoutTests.m
@@ -187,11 +187,11 @@
     [self.env.nikRd2Repo run:^(GitRepository * _Nonnull repo) {
         s7init_deactivateHooks();
         
-        s7add_stage(@"Dependencies/ReaddleLib", self.env.githubReaddleLibRepo.absolutePath);
+        GitRepository *const readdleLib = s7add_stage(@"Dependencies/ReaddleLib",
+                                                      self.env.githubReaddleLibRepo.absolutePath);
         [repo commitWithMessage:@"add ReaddleLib subrepo"];
         s7push_currentBranch(repo);
         
-        GitRepository *const readdleLib = [GitRepository repoAtPath:@"Dependencies/ReaddleLib"];
         [readdleLib checkoutNewLocalBranch:@"experiment/srgb"];
         commit(readdleLib, @"NSColor+RD.h", @"sRGB", @"repaint");
         // with this option I was able to create situation when

--- a/system7/Utils/Utils.h
+++ b/system7/Utils/Utils.h
@@ -24,6 +24,8 @@ BOOL isCurrentDirectoryS7RepoRoot(void);
 int s7RepoPreconditionCheck(void);
 int saveUpdatedConfigToMainAndControlFile(S7Config *updatedConfig);
 
+NSString *_Nullable getGlobalGitConfigValue(NSString *key);
+
 #define S7_REPO_PRECONDITION_CHECK()                    \
     do {                                                \
         const int result = s7RepoPreconditionCheck();   \

--- a/system7/Utils/Utils.m
+++ b/system7/Utils/Utils.m
@@ -139,3 +139,24 @@ int saveUpdatedConfigToMainAndControlFile(S7Config *updatedConfig) {
 
     return S7ExitCodeSuccess;
 }
+
+NSString *getGlobalGitConfigValue(NSString *key) {
+    NSCParameterAssert(key != nil);
+    NSString *const launch = [NSString stringWithFormat:@"git config --global --get %@", key];
+    FILE *const proc = popen([launch cStringUsingEncoding:NSUTF8StringEncoding], "r");
+    if (proc == NULL) {
+        return nil;
+    }
+    
+    NSMutableString *const value = [NSMutableString new];
+    char buffer[16];
+    while (fgets(buffer, sizeof(buffer) / sizeof(char), proc)) {
+        [value appendFormat:@"%s", buffer];
+    }
+    
+    if (pclose(proc) != 0) {
+        return nil;
+    }
+    
+    return [value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}

--- a/system7/git/Git.m
+++ b/system7/git/Git.m
@@ -322,6 +322,7 @@ static void (^_testRepoConfigureOnInitBlock)(GitRepository *);
     }
         
     if ([self doesBranchExist:[NSString stringWithFormat:@"origin/%@", branchName]] == NO) {
+        fprintf(stderr, "failed to checkout remote tracking branch: remote branch '%s' doesn't exist.\n", [branchName cStringUsingEncoding:NSUTF8StringEncoding]);
         return S7ExitCodeGitOperationFailed;
     }
     


### PR DESCRIPTION
во-первых добавил конфигурацию для репозиториев, её можно просовывать через environment - это из-за особенностей моего локального сетапа, но может быть полезно другим

багина: есть локальная ветка, её силой впихнули на ремоут, трекинга нет, при переключении на неё s7 не видит трекинга и пытается зачекаутить её заново, но получает ошибку. залепил чекаутом локальной ветки as is