### PR TITLE
autoflush stdout to get predictable output instead of a confusing sal…

### DIFF
--- a/system7/Hooks/S7PostCheckoutHook.m
+++ b/system7/Hooks/S7PostCheckoutHook.m
@@ -342,7 +342,6 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
                         [subrepoDesc.path fileSystemRepresentation],
                         [currentUrl cStringUsingEncoding:NSUTF8StringEncoding],
                         [subrepoDesc.url cStringUsingEncoding:NSUTF8StringEncoding]);
-                fflush(stdout);
 
                 NSError *error = nil;
                 if (NO == [[NSFileManager defaultManager] removeItemAtPath:subrepoDesc.path error:&error]) {
@@ -361,7 +360,6 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
                     " cloning subrepo '%s' from '%s'\n",
                     [subrepoDesc.path fileSystemRepresentation],
                     [subrepoDesc.url fileSystemRepresentation]);
-            fflush(stdout); // flush to make sure that *what is cloned* comes before errors if they arise
 
             int cloneExitStatus = 0;
             subrepoGit = [GitRepository

--- a/system7/Hooks/S7PrePushHook.m
+++ b/system7/Hooks/S7PrePushHook.m
@@ -354,10 +354,6 @@
         fprintf(stdout,
                 " checking '%s' ... ",
                 subrepoPath.fileSystemRepresentation);
-        // flush here 'cause next commands (for example, -isRevision:knownAtRemoteBranch:)
-        // may spawn some output to stderr, and user sees 'error: blah-blah...' and 'checking'
-        // in the wrong order, so the log seems wrong
-        fflush(stdout);
 
         GitRepository *subrepoGit = [GitRepository repoAtPath:subrepoPath];
         if (nil == subrepoGit) {

--- a/system7/main.m
+++ b/system7/main.m
@@ -274,6 +274,26 @@ void upgradeHooksToUsrLocalBin() {
 }
 
 int main(int argc, const char * argv[]) {
+    // Turn off stdout buffering to make sure that the order of output corresponds to the logic we have in code.
+    // stderr is not buffered by default. If we don't flush stdout after each fprintf,
+    // then in case of error, we get a confusing output in terminal. For example:
+    //
+    //   checking out subrepo X
+    //   blah-blah
+    //   error: blah-blah
+    //   blah-blah
+    //   checking out subrepo Y
+    //
+    // instead of expected:
+    //
+    //   checking out subrepo X
+    //   blah-blah
+    //   checking out subrepo Y
+    //   error: blah-blah
+    //   blah-blah
+    //
+    setbuf(stdout, NULL);
+
     if (argc < 2) {
         helpCommand(@[]);
         return S7ExitCodeUnknownCommand;


### PR DESCRIPTION
…ad of stderr/stdout

Периодически, когда возникают какие-то ошибки, наблюдаю, что вывод stdout-а (который логически в коде идет до кода, который выводит ошибку), оказывается после stderr-а. Читать такие логи крайне сложно.
До этого лечил это в конкретных местах.
Я знал, что можно отрубить буферизацию, но меня смущало это требование "This function [setvbuf] should be called once the stream has been associated with an open file, but before any input or output operation is performed with it.". Я думал о высоких материях, типа – а что если некая библиотека до вызова main попытается писать в stdout? Сейчас думаю, что можно не париться: 1. вижу достаточно много примеров такой настройки в начале main; 2. задолбался руками тыкать везде fflush, и уже готов рискнуть