### PR TITLE
delete unused 'possibleOptions' parameter

### DIFF
--- a/system7-tests/mergeTests.m
+++ b/system7-tests/mergeTests.m
@@ -467,13 +467,11 @@
         S7ConfigMergeDriver *configMergeDriver = [S7ConfigMergeDriver new];
         __block int callNumber = 0;
         [configMergeDriver setResolveConflictBlock:^S7ConflictResolutionOption(S7SubrepoDescription * _Nonnull ourVersion,
-                                                                          S7SubrepoDescription * _Nonnull theirVersion,
-                                                                          S7ConflictResolutionOption possibleOptions)
+                                                                          S7SubrepoDescription * _Nonnull theirVersion)
          {
             XCTAssertEqualObjects(ourVersion.path, @"Dependencies/ReaddleLib");
-            S7ConflictResolutionOption expectedResolutionOptions =
-                S7ConflictResolutionOptionKeepLocal | S7ConflictResolutionOptionKeepRemote | S7ConflictResolutionOptionMerge;
-            XCTAssertEqual(expectedResolutionOptions, possibleOptions);
+//            possibleOptions:
+//                S7ConflictResolutionOptionKeepLocal | S7ConflictResolutionOptionKeepRemote | S7ConflictResolutionOptionMerge;
 
             ++callNumber;
 
@@ -594,13 +592,11 @@
 
         S7ConfigMergeDriver *configMergeDriver = [S7ConfigMergeDriver new];
         [configMergeDriver setResolveConflictBlock:^S7ConflictResolutionOption(S7SubrepoDescription * _Nonnull ourVersion,
-                                                                          S7SubrepoDescription * _Nonnull theirVersion,
-                                                                          S7ConflictResolutionOption possibleOptions)
+                                                                          S7SubrepoDescription * _Nonnull theirVersion)
          {
             XCTAssertEqualObjects(ourVersion.path, @"Dependencies/ReaddleLib");
-            S7ConflictResolutionOption expectedResolutionOptions =
-                S7ConflictResolutionOptionKeepLocal | S7ConflictResolutionOptionKeepRemote | S7ConflictResolutionOptionMerge;
-            XCTAssertEqual(expectedResolutionOptions, possibleOptions);
+//            possibleOptions:
+//                S7ConflictResolutionOptionKeepLocal | S7ConflictResolutionOptionKeepRemote | S7ConflictResolutionOptionMerge;
 
             return S7ConflictResolutionOptionMerge;
          }];
@@ -726,13 +722,11 @@
 
         S7ConfigMergeDriver *configMergeDriver = [S7ConfigMergeDriver new];
         [configMergeDriver setResolveConflictBlock:^S7ConflictResolutionOption(S7SubrepoDescription * _Nonnull ourVersion,
-                                                                               S7SubrepoDescription * _Nonnull theirVersion,
-                                                                               S7ConflictResolutionOption possibleOptions)
+                                                                               S7SubrepoDescription * _Nonnull theirVersion)
          {
             XCTAssertEqualObjects(ourVersion.path, @"Dependencies/ReaddleLib");
-            S7ConflictResolutionOption expectedResolutionOptions =
-            S7ConflictResolutionOptionKeepLocal | S7ConflictResolutionOptionKeepRemote | S7ConflictResolutionOptionMerge;
-            XCTAssertEqual(expectedResolutionOptions, possibleOptions);
+//            possibleOptions:
+//                S7ConflictResolutionOptionKeepLocal | S7ConflictResolutionOptionKeepRemote | S7ConflictResolutionOptionMerge;
 
             return S7ConflictResolutionOptionKeepLocal;
         }];
@@ -833,13 +827,11 @@
 
         S7ConfigMergeDriver *configMergeDriver = [S7ConfigMergeDriver new];
         [configMergeDriver setResolveConflictBlock:^S7ConflictResolutionOption(S7SubrepoDescription * _Nonnull ourVersion,
-                                                                               S7SubrepoDescription * _Nonnull theirVersion,
-                                                                               S7ConflictResolutionOption possibleOptions)
+                                                                               S7SubrepoDescription * _Nonnull theirVersion)
          {
             XCTAssertEqualObjects(ourVersion.path, @"Dependencies/ReaddleLib");
-            S7ConflictResolutionOption expectedResolutionOptions =
-            S7ConflictResolutionOptionKeepLocal | S7ConflictResolutionOptionKeepRemote | S7ConflictResolutionOptionMerge;
-            XCTAssertEqual(expectedResolutionOptions, possibleOptions);
+//            possibleOptions:
+//                S7ConflictResolutionOptionKeepLocal | S7ConflictResolutionOptionKeepRemote | S7ConflictResolutionOptionMerge;
 
             return S7ConflictResolutionOptionKeepRemote;
         }];
@@ -941,15 +933,13 @@
 
         S7ConfigMergeDriver *configMergeDriver = [S7ConfigMergeDriver new];
         [configMergeDriver setResolveConflictBlock:^S7ConflictResolutionOption(S7SubrepoDescription * _Nonnull ourVersion,
-                                                                               S7SubrepoDescription * _Nonnull theirVersion,
-                                                                               S7ConflictResolutionOption possibleOptions)
+                                                                               S7SubrepoDescription * _Nonnull theirVersion)
          {
             XCTAssertNil(ourVersion);
             XCTAssertEqualObjects(theirVersion.path, @"Dependencies/ReaddleLib");
 
-            S7ConflictResolutionOption expectedResolutionOptions =
-            S7ConflictResolutionOptionKeepChanged | S7ConflictResolutionOptionDelete;
-            XCTAssertEqual(expectedResolutionOptions, possibleOptions);
+//            possibleOptions:
+//                S7ConflictResolutionOptionKeepChanged | S7ConflictResolutionOptionDelete;
 
             return S7ConflictResolutionOptionDelete;
         }];
@@ -1045,15 +1035,13 @@
 
         S7ConfigMergeDriver *configMergeDriver = [S7ConfigMergeDriver new];
         [configMergeDriver setResolveConflictBlock:^S7ConflictResolutionOption(S7SubrepoDescription * _Nonnull ourVersion,
-                                                                               S7SubrepoDescription * _Nonnull theirVersion,
-                                                                               S7ConflictResolutionOption possibleOptions)
+                                                                               S7SubrepoDescription * _Nonnull theirVersion)
          {
             XCTAssertNil(ourVersion);
             XCTAssertEqualObjects(theirVersion.path, @"Dependencies/ReaddleLib");
 
-            S7ConflictResolutionOption expectedResolutionOptions =
-            S7ConflictResolutionOptionKeepChanged | S7ConflictResolutionOptionDelete;
-            XCTAssertEqual(expectedResolutionOptions, possibleOptions);
+//            possibleOptions:
+//                S7ConflictResolutionOptionKeepChanged | S7ConflictResolutionOptionDelete;
 
             return S7ConflictResolutionOptionKeepChanged;
         }];

--- a/system7/Merge Driver/S7ConfigMergeDriver.h
+++ b/system7/Merge Driver/S7ConfigMergeDriver.h
@@ -26,8 +26,7 @@ typedef NS_OPTIONS(uint32_t, S7ConflictResolutionOption) {
 - (int)runWithArguments:(NSArray<NSString *> *)arguments;
 
 @property (nonatomic) S7ConflictResolutionOption (^resolveConflictBlock)(S7SubrepoDescription * _Nullable ourVersion,
-                                                                         S7SubrepoDescription * _Nullable theirVersion,
-                                                                         S7ConflictResolutionOption possibleOptions);
+                                                                         S7SubrepoDescription * _Nullable theirVersion);
 
 + (S7Config *)mergeOurConfig:(S7Config *)ourLines
                  theirConfig:(S7Config *)theirConfig

--- a/system7/Merge Driver/S7ConfigMergeDriver.m
+++ b/system7/Merge Driver/S7ConfigMergeDriver.m
@@ -23,8 +23,7 @@
     }
 
     [self setResolveConflictBlock:^S7ConflictResolutionOption(S7SubrepoDescription * _Nullable ourVersion,
-                                                              S7SubrepoDescription * _Nullable theirVersion,
-                                                              S7ConflictResolutionOption possibleOptions)
+                                                              S7SubrepoDescription * _Nullable theirVersion)
      {
         void *self __attribute((unused)) __attribute((unavailable));
 
@@ -32,11 +31,6 @@
         char buf[BUF_LEN];
 
         if (ourVersion && theirVersion) {
-            NSCAssert(possibleOptions == (S7ConflictResolutionOptionKeepLocal |
-                                          S7ConflictResolutionOptionKeepRemote |
-                                          S7ConflictResolutionOptionMerge),
-                      @"");
-
             // should write this to stdout or stderr?
             fprintf(stdout,
                     " subrepo '%s' diverged\n"
@@ -72,9 +66,6 @@
         }
         else {
             NSCAssert(ourVersion || theirVersion, @"");
-            NSCAssert(possibleOptions == (S7ConflictResolutionOptionKeepChanged |
-                                          S7ConflictResolutionOptionDelete),
-                      @"");
 
             if (ourVersion) {
                 fprintf(stdout,
@@ -441,8 +432,7 @@ saveResultToFilePath:(NSString *)resultFilePath
                 }
 
                 userDecision = self.resolveConflictBlock(conflict.ourVersion,
-                                                         conflict.theirVersion,
-                                                         possibleConflictResolutionOptions);
+                                                         conflict.theirVersion);
 
                 if (NO == isExactlyOneBitSetInNumber(userDecision)) {
                     continue;


### PR DESCRIPTION
It was confusing for the calling site. In real life the only 'real' user of this parameter were unit tests; actual main code checks returned option to match possible options