### PR TITLE
extract bootstrap into separate command

### DIFF
--- a/buildme.sh
+++ b/buildme.sh
@@ -68,4 +68,4 @@ cp update.sh "/usr/local/bin/update-s7.sh"
 
 # register s7 filter smudge that is used to bootstrap (automatically init) s7 repos on clone
 #
-git config --global filter.s7.smudge "s7 init --bootstrap"
+git config --global filter.s7.smudge "s7 bootstrap"

--- a/system7-tests/bootstrapTests.m
+++ b/system7-tests/bootstrapTests.m
@@ -1,5 +1,5 @@
 //
-//  initBootstrapTests.m
+//  bootstrapTests.m
 //  system7-tests
 //
 //  Created by Pavlo Shkrabliuk on 27.11.2020.
@@ -8,15 +8,15 @@
 
 #import <XCTest/XCTest.h>
 
-#import "S7InitCommand.h"
+#import "S7BootstrapCommand.h"
 
 #import "TestReposEnvironment.h"
 
-@interface initBootstrapTests : XCTestCase
+@interface bootstrapTests : XCTestCase
 @property (nonatomic, strong) TestReposEnvironment *env;
 @end
 
-@implementation initBootstrapTests
+@implementation bootstrapTests
 
 - (void)setUp {
     self.env = [[TestReposEnvironment alloc] initWithTestCaseName:self.className];
@@ -29,9 +29,9 @@
 // these tests are pure emulation – filter is not really called by Git
 
 - (void)runBootstrap {
-    S7InitCommand *initBootstrapCommand = [S7InitCommand new];
-    initBootstrapCommand.runFakeFilter = YES;
-    const int exitCode = [initBootstrapCommand runWithArguments:@[@"--bootstrap"]];
+    S7BootstrapCommand *command = [S7BootstrapCommand new];
+    command.runFakeFilter = YES;
+    const int exitCode = [command runWithArguments:@[]];
     XCTAssertEqual(0, exitCode);
 }
 

--- a/system7.xcodeproj/project.pbxproj
+++ b/system7.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		BE8218812452C16A00E878A8 /* S7Config.m in Sources */ = {isa = PBXBuildFile; fileRef = BE8218802452C16A00E878A8 /* S7Config.m */; };
 		BE8218892452C1DE00E878A8 /* configParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BE8218882452C1DE00E878A8 /* configParserTests.m */; };
 		BE82188E2452C1ED00E878A8 /* S7Config.m in Sources */ = {isa = PBXBuildFile; fileRef = BE8218802452C16A00E878A8 /* S7Config.m */; };
+		BE90D390258F470900186E86 /* S7BootstrapCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = BE90D38F258F470900186E86 /* S7BootstrapCommand.m */; };
+		BE90D391258F470900186E86 /* S7BootstrapCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = BE90D38F258F470900186E86 /* S7BootstrapCommand.m */; };
 		BEBD16952455824400E81673 /* diffTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BEBD16942455824400E81673 /* diffTests.m */; };
 		BED36BE0246D8A1700D6EB1C /* S7PostCheckoutHook.m in Sources */ = {isa = PBXBuildFile; fileRef = BED36BDF246D8A1700D6EB1C /* S7PostCheckoutHook.m */; };
 		BED36BE1246D8A1700D6EB1C /* S7PostCheckoutHook.m in Sources */ = {isa = PBXBuildFile; fileRef = BED36BDF246D8A1700D6EB1C /* S7PostCheckoutHook.m */; };
@@ -71,7 +73,7 @@
 		BEE672C92523B72200DB09BC /* S7IniConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = BEE672C72523B72200DB09BC /* S7IniConfig.m */; };
 		BEE672CF2523B76500DB09BC /* iniParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BEE672CE2523B76500DB09BC /* iniParserTests.m */; };
 		BEE928A12456DA6500BD6B86 /* Git.m in Sources */ = {isa = PBXBuildFile; fileRef = BEE928A02456DA6500BD6B86 /* Git.m */; };
-		BEFAF7A125718AB7000D90C3 /* initBootstrapTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BEFAF7A025718AB7000D90C3 /* initBootstrapTests.m */; };
+		BEFAF7A125718AB7000D90C3 /* bootstrapTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BEFAF7A025718AB7000D90C3 /* bootstrapTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -135,6 +137,8 @@
 		BE8218862452C1DE00E878A8 /* system7-tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "system7-tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BE8218882452C1DE00E878A8 /* configParserTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = configParserTests.m; sourceTree = "<group>"; };
 		BE82188A2452C1DE00E878A8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		BE90D38E258F470900186E86 /* S7BootstrapCommand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = S7BootstrapCommand.h; sourceTree = "<group>"; };
+		BE90D38F258F470900186E86 /* S7BootstrapCommand.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = S7BootstrapCommand.m; sourceTree = "<group>"; };
 		BEBD16942455824400E81673 /* diffTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = diffTests.m; sourceTree = "<group>"; };
 		BED36BDE246D8A1700D6EB1C /* S7PostCheckoutHook.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = S7PostCheckoutHook.h; sourceTree = "<group>"; };
 		BED36BDF246D8A1700D6EB1C /* S7PostCheckoutHook.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = S7PostCheckoutHook.m; sourceTree = "<group>"; };
@@ -160,7 +164,7 @@
 		BEE672CE2523B76500DB09BC /* iniParserTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = iniParserTests.m; sourceTree = "<group>"; };
 		BEE9289F2456DA6500BD6B86 /* Git.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Git.h; sourceTree = "<group>"; };
 		BEE928A02456DA6500BD6B86 /* Git.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Git.m; sourceTree = "<group>"; };
-		BEFAF7A025718AB7000D90C3 /* initBootstrapTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = initBootstrapTests.m; sourceTree = "<group>"; };
+		BEFAF7A025718AB7000D90C3 /* bootstrapTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = bootstrapTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -263,7 +267,7 @@
 				BE8218882452C1DE00E878A8 /* configParserTests.m */,
 				BEBD16942455824400E81673 /* diffTests.m */,
 				BE3A29F124607234004A2B31 /* initTests.m */,
-				BEFAF7A025718AB7000D90C3 /* initBootstrapTests.m */,
+				BEFAF7A025718AB7000D90C3 /* bootstrapTests.m */,
 				BE3A29F324607419004A2B31 /* addTests.m */,
 				BE3892102463049300394CA8 /* removeTests.m */,
 				BE4BB43B24615CFD00545358 /* rebindTests.m */,
@@ -312,6 +316,8 @@
 				BE0173E324864EBF00BA4B2F /* S7ResetCommand.m */,
 				BE394D3A2486ADB500ED6E05 /* S7CheckoutCommand.h */,
 				BE394D3B2486ADB500ED6E05 /* S7CheckoutCommand.m */,
+				BE90D38E258F470900186E86 /* S7BootstrapCommand.h */,
+				BE90D38F258F470900186E86 /* S7BootstrapCommand.m */,
 			);
 			path = Commands;
 			sourceTree = "<group>";
@@ -446,6 +452,7 @@
 				BED36BEA246E904E00D6EB1C /* S7PostMergeHook.m in Sources */,
 				BE3A29E824604D1B004A2B31 /* S7StatusCommand.m in Sources */,
 				BE0173E424864EBF00BA4B2F /* S7ResetCommand.m in Sources */,
+				BE90D390258F470900186E86 /* S7BootstrapCommand.m in Sources */,
 				BE8218812452C16A00E878A8 /* S7Config.m in Sources */,
 				BE172CD224657CA700B57557 /* S7Diff.m in Sources */,
 				BE389214246304F200394CA8 /* S7RemoveCommand.m in Sources */,
@@ -481,7 +488,7 @@
 				BEBD16952455824400E81673 /* diffTests.m in Sources */,
 				BE389215246304F200394CA8 /* S7RemoveCommand.m in Sources */,
 				BE50AA01246C2CB800DBB618 /* S7PrePushHook.m in Sources */,
-				BEFAF7A125718AB7000D90C3 /* initBootstrapTests.m in Sources */,
+				BEFAF7A125718AB7000D90C3 /* bootstrapTests.m in Sources */,
 				BEE672CF2523B76500DB09BC /* iniParserTests.m in Sources */,
 				BE1079C12466C557002A2A45 /* S7SubrepoDescription.m in Sources */,
 				BED36BE7246E809000D6EB1C /* S7PostCommitHook.m in Sources */,
@@ -492,6 +499,7 @@
 				BE3891042461690500394CA8 /* TestUtils.m in Sources */,
 				BE172CD324657CA700B57557 /* S7Diff.m in Sources */,
 				BED36BEB246E904E00D6EB1C /* S7PostMergeHook.m in Sources */,
+				BE90D391258F470900186E86 /* S7BootstrapCommand.m in Sources */,
 				BED36BE3246D8A4B00D6EB1C /* postCheckoutHookTests.m in Sources */,
 				BE1079BD2466C516002A2A45 /* S7SubrepoDescriptionConflict.m in Sources */,
 				BE4BB43C24615CFD00545358 /* rebindTests.m in Sources */,
@@ -568,6 +576,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -624,6 +633,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				OTHER_LDFLAGS = "-Wl,-fatal_warnings";

--- a/system7/Commands/S7BootstrapCommand.h
+++ b/system7/Commands/S7BootstrapCommand.h
@@ -1,0 +1,21 @@
+//
+//  S7BootstrapCommand.h
+//  system7
+//
+//  Created by Pavlo Shkrabliuk on 20.12.2020.
+//  Copyright © 2020 Readdle. All rights reserved.
+//
+
+#import "S7Command.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface S7BootstrapCommand : NSObject <S7Command>
+
+@property (nonatomic, assign) BOOL runFakeFilter;
+
++ (NSString *)bootstrapCommandLine;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/system7/Commands/S7BootstrapCommand.m
+++ b/system7/Commands/S7BootstrapCommand.m
@@ -1,0 +1,114 @@
+//
+//  S7BootstrapCommand.m
+//  system7
+//
+//  Created by Pavlo Shkrabliuk on 20.12.2020.
+//  Copyright © 2020 Readdle. All rights reserved.
+//
+
+#import "S7BootstrapCommand.h"
+
+#import "Utils.h"
+#import "HelpPager.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation S7BootstrapCommand
+
++ (NSString *)commandName {
+    return @"bootstrap";
+}
+
++ (NSArray<NSString *> *)aliases {
+    return @[];
+}
+
++ (void)printCommandHelp {
+    help_puts("s7 bootstrap");
+    help_puts("");
+    help_puts("Service command used to automatically run `s7 init` in a new repo clone.");
+    help_puts("");
+    help_puts("You should not use this command unless you are s7 itself or s7 developer.");
+    help_puts("Read the contents of .s7bootstrap file in any existing s7 repo for more");
+    help_puts("info about the bootstrap process.");
+}
+
+- (int)runWithArguments:(NSArray<NSString *> *)arguments {
+    if ([self shouldInstallBootstrap]) {
+        // we may still fail to install bootstrap, for example, if post-checkout hook exists
+        // and it's not a shell script (where we can merge in)
+        //
+        installHook(@"post-checkout", [[self class] bootstrapCommandLine], NO, NO);
+    }
+
+    // according to https://git-scm.com/docs/gitattributes
+    //  "filter driver that exits with a non-zero status, is not an error but makes the filter a no-op passthru."
+    // but in reality, if filter exist with non-zero, Git writes:
+    //  "error: external filter '...' failed 1"
+    // it doesn't affect the clone process, but looks ugly.
+    // So... we'd have to actually perform the "filter" and exit gracefully
+    //
+    if (NO == self.runFakeFilter) {
+        char c;
+        while ((c=getchar()) != EOF) {
+            putchar(c);
+        }
+    }
+
+    return 0;
+}
+
+- (BOOL)shouldInstallBootstrap {
+    if ([self willBootstrapConflictWithGitLFS]) {
+        return NO;
+    }
+
+    if ([NSFileManager.defaultManager fileExistsAtPath:S7ControlFileName]) {
+        // If repo contains .s7control, then user has already done some work in it
+        // which implies that s7 IS initialized in the repo.
+        // If we install bootstrap at such repo, then it will install bootstrap into
+        // post-checkout hook, but the actual `s7 init` won't be called in the process
+        // of checkout, as .s7control exists
+        //
+        return NO;
+    }
+
+    return YES;
+}
+
+- (BOOL)willBootstrapConflictWithGitLFS {
+    NSError *error = nil;
+    NSString *gitattributesContent = [[NSString alloc] initWithContentsOfFile:@".gitattributes" encoding:NSUTF8StringEncoding error:&error];
+    if (nil != error) {
+        // Such situation would be really unexpected – how would Git find out
+        // that it should filter .s7bootstrap if there's no .gitattributes?
+        // Maybe something wrong with the permissions?
+        // Anyway, if we cannot read .gitattributes, then we better avoid bootstrap.
+        //
+        fprintf(stderr, "s7 bootstrap: failed to read contents of .gitattributes file. Error: %s\n",
+                [[error description] cStringUsingEncoding:NSUTF8StringEncoding]);
+        return YES;
+    }
+
+    if ([gitattributesContent containsString:@"filter=lfs"]) {
+        // this repo contains some LFS files.
+        // If LFS hook is NOT installed, then we do not install bootstrap hook
+        // not to cause LFS hook install failure. In such case user will have to
+        // run `s7 init` manually 🤷‍♂️
+        // If LFS hook IS installed, we can still merge-in bootstrap command into it.
+        //
+        if (NO == [NSFileManager.defaultManager fileExistsAtPath:@".git/hooks/post-checkout"]) {
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
++ (NSString *)bootstrapCommandLine {
+    return @"/usr/local/bin/s7 init";
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/system7/Commands/S7InitCommand.h
+++ b/system7/Commands/S7InitCommand.h
@@ -13,9 +13,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface S7InitCommand : NSObject <S7Command>
 
 @property (nonatomic, assign) BOOL installFakeHooks;
-@property (nonatomic, assign) BOOL runFakeFilter;
-
-+ (NSString *)bootstrapCommandLine;
 
 @end
 

--- a/system7/Commands/S7InitCommand.m
+++ b/system7/Commands/S7InitCommand.m
@@ -16,6 +16,7 @@
 #import "S7PostCommitHook.h"
 #import "S7PostMergeHook.h"
 #import "S7PrepareCommitMsgHook.h"
+#import "S7BootstrapCommand.h"
 
 @interface S7InitCommand ()
 
@@ -104,14 +105,10 @@
     }
 
     BOOL createBootstrapFile = YES;
-    BOOL bootstrap = NO;
 
     for (NSString *argument in arguments) {
         if ([argument isEqualToString:@"-f"] || [argument isEqualToString:@"--force"]) {
             self.forceOverwriteHooks = YES;
-        }
-        else if ([argument isEqualToString:@"--bootstrap"]) {
-            bootstrap = YES;
         }
         else if ([argument isEqualToString:@"--no-bootstrap"]) {
             createBootstrapFile = NO;
@@ -119,10 +116,6 @@
         else {
             return S7ExitCodeUnrecognizedOption;
         }
-    }
-
-    if (bootstrap) {
-        return [self bootstrap];
     }
 
     BOOL isDirectory = NO;
@@ -224,83 +217,6 @@
     return S7ExitCodeSuccess;
 }
 
-- (int)bootstrap {
-    if ([self shouldInstallBootstrap]) {
-        // we may still fail to install bootstrap, for example, if post-checkout hook exists
-        // and it's not a shell script (where we can merge in)
-        [self
-         installHook:@"post-checkout"
-         commandLine:[[self class] bootstrapCommandLine]];
-    }
-
-    // according to https://git-scm.com/docs/gitattributes
-    //  "filter driver that exits with a non-zero status, is not an error but makes the filter a no-op passthru."
-    // but in reality, if filter exist with non-zero, Git writes:
-    //  "error: external filter '...' failed 1"
-    // it doesn't affect the clone process, but looks ugly.
-    // So... we'd have to actually perform the "filter" and exit gracefully
-    //
-    if (NO == self.runFakeFilter) {
-        char c;
-        while ((c=getchar()) != EOF) {
-            putchar(c);
-        }
-    }
-
-    return 0;
-}
-
-- (BOOL)shouldInstallBootstrap {
-    if ([self willBootstrapConflictWithGitLFS]) {
-        return NO;
-    }
-
-    if ([NSFileManager.defaultManager fileExistsAtPath:S7ControlFileName]) {
-        // If repo contains .s7control, then user has already done some work in it
-        // which implies that s7 IS initialized in the repo.
-        // If we install bootstrap at such repo, then it will install bootstrap into
-        // post-checkout hook, but the actual `s7 init` won't be called in the process
-        // of checkout, as .s7control exists
-        //
-        return NO;
-    }
-
-    return YES;
-}
-
-- (BOOL)willBootstrapConflictWithGitLFS {
-    NSError *error = nil;
-    NSString *gitattributesContent = [[NSString alloc] initWithContentsOfFile:@".gitattributes" encoding:NSUTF8StringEncoding error:&error];
-    if (nil != error) {
-        // Such situation would be really unexpected – how would Git find out
-        // that it should filter .s7bootstrap if there's no .gitattributes?
-        // Maybe something wrong with the permissions?
-        // Anyway, if we cannot read .gitattributes, then we better avoid bootstrap.
-        //
-        fprintf(stderr, "s7 bootstrap: failed to read contents of .gitattributes file. Error: %s\n",
-                [[error description] cStringUsingEncoding:NSUTF8StringEncoding]);
-        return YES;
-    }
-
-    if ([gitattributesContent containsString:@"filter=lfs"]) {
-        // this repo contains some LFS files.
-        // If LFS hook is NOT installed, then we do not install bootstrap hook
-        // not to cause LFS hook install failure. In such case user will have to
-        // run `s7 init` manually 🤷‍♂️
-        // If LFS hook IS installed, we can still merge-in bootstrap command into it.
-        //
-        if (NO == [NSFileManager.defaultManager fileExistsAtPath:@".git/hooks/post-checkout"]) {
-            return YES;
-        }
-    }
-
-    return NO;
-}
-
-+ (NSString *)bootstrapCommandLine {
-    return @"/usr/local/bin/s7 init";
-}
-
 - (int)installHook:(Class<S7Hook>)hookClass {
     // there's no guarantie that s7 will be the only one citizen of a hook,
     // thus we add " || exit $?" – to exit hook properly if s7 hook fails
@@ -309,111 +225,7 @@
                              @"/usr/local/bin/s7 %@-hook \"$@\" <&0 || exit $?",
                              [hookClass gitHookName]];
 
-    return [self installHook:[hookClass gitHookName]
-                 commandLine:commandLine];
-}
-
-- (int)installHook:(NSString *)hookName commandLine:(NSString *)commandLine {
-    NSString *hookFilePath = [@".git/hooks" stringByAppendingPathComponent:hookName];
-
-    NSString *contentsToWrite = [NSString stringWithFormat:@"#!/bin/sh\n\n%@\n", commandLine];
-
-    if (NO == self.forceOverwriteHooks && [NSFileManager.defaultManager fileExistsAtPath:hookFilePath]) {
-        NSString *existingContents = [[NSString alloc] initWithContentsOfFile:hookFilePath encoding:NSUTF8StringEncoding error:nil];
-        if (NO == [existingContents hasPrefix:@"#!/bin/sh\n"]) {
-            fprintf(stderr,
-                    "\033[31m"
-                    "hook %s already exists and it's not a shell script, so we cannot merge s7 call into it\n"
-                    "\033[0m",
-                    hookFilePath.fileSystemRepresentation);
-
-            return S7ExitCodeFileOperationFailed;
-        }
-
-        if ([existingContents containsString:commandLine]) {
-            return 0;
-        }
-
-        NSString *oldStyleS7HookContents = [NSString
-                                            stringWithFormat:
-                                            @"#!/bin/sh\n"
-                                            "/usr/local/bin/s7 %@-hook \"$@\" <&0",
-                                            hookName];
-        if (NO == [existingContents isEqualToString:oldStyleS7HookContents]) {
-            NSString *existingHookBody = [existingContents stringByReplacingOccurrencesOfString:@"#!/bin/sh\n"
-                                                                                     withString:@""];
-
-            // 'uninstall' bootstrap command
-            existingHookBody = [existingHookBody stringByReplacingOccurrencesOfString:[[self class] bootstrapCommandLine]
-                                                                           withString:@""];
-
-            NSString *mergedHookContents = [NSString stringWithFormat:
-                                            @"#!/bin/sh\n"
-                                            "\n"
-                                            "%@\n"
-                                            "\n"
-                                            "%@",
-                                            commandLine,
-                                            existingHookBody];
-
-            contentsToWrite = mergedHookContents;
-        }
-    }
-
-    if (self.installFakeHooks) {
-        contentsToWrite = @"";
-    }
-
-    NSError *error = nil;
-    if (NO == [NSFileManager.defaultManager fileExistsAtPath:@".git/hooks"]) {
-        if (NO == [NSFileManager.defaultManager
-                   createDirectoryAtPath:@".git/hooks"
-                   withIntermediateDirectories:NO
-                   attributes:nil
-                   error:&error])
-        {
-            fprintf(stderr,
-                    "'.git/hooks' directory doesn't exist. Failed to create it. Error: %s\n",
-                    [[error description] cStringUsingEncoding:NSUTF8StringEncoding]);
-
-            return S7ExitCodeFileOperationFailed;
-        }
-    }
-
-    if (NO == [contentsToWrite writeToFile:hookFilePath atomically:YES encoding:NSUTF8StringEncoding error:&error]) {
-        fprintf(stderr,
-                "failed to save %s to disk. Error: %s\n",
-                hookFilePath.fileSystemRepresentation,
-                [[error description] cStringUsingEncoding:NSUTF8StringEncoding]);
-
-        return S7ExitCodeFileOperationFailed;
-    }
-
-    NSUInteger posixPermissions = [NSFileManager.defaultManager attributesOfItemAtPath:hookFilePath error:&error].filePosixPermissions;
-    if (error) {
-        fprintf(stderr,
-                "failed to read %s posix permissions. Error: %s\n",
-                hookFilePath.fileSystemRepresentation,
-                [[error description] cStringUsingEncoding:NSUTF8StringEncoding]);
-
-        return S7ExitCodeFileOperationFailed;
-    }
-
-    posixPermissions |= 0111;
-
-    if (NO == [NSFileManager.defaultManager setAttributes:@{ NSFilePosixPermissions : @(posixPermissions) }
-                                             ofItemAtPath:hookFilePath
-                                                    error:&error])
-    {
-        fprintf(stderr,
-                "failed to make hook %s executable. Error: %s\n",
-                hookFilePath.fileSystemRepresentation,
-                [[error description] cStringUsingEncoding:NSUTF8StringEncoding]);
-
-        return S7ExitCodeFileOperationFailed;
-    }
-
-    return 0;
+    return installHook([hookClass gitHookName],commandLine, self.forceOverwriteHooks, self.installFakeHooks);
 }
 
 - (int)installS7ConfigMergeDriver {

--- a/system7/Hooks/S7PostCheckoutHook.m
+++ b/system7/Hooks/S7PostCheckoutHook.m
@@ -9,8 +9,9 @@
 #import "S7PostCheckoutHook.h"
 
 #import "S7Diff.h"
-#import "S7InitCommand.h"
 #import "Utils.h"
+#import "S7InitCommand.h"
+#import "S7BootstrapCommand.h"
 
 static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberOfCommits) = nil;
 
@@ -800,7 +801,7 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
 
     NSString *existingContents = [[NSString alloc] initWithContentsOfFile:hookFilePath encoding:NSUTF8StringEncoding error:nil];
 
-    NSString *updatedContents = [existingContents stringByReplacingOccurrencesOfString:[[S7InitCommand class] bootstrapCommandLine]
+    NSString *updatedContents = [existingContents stringByReplacingOccurrencesOfString:[[S7BootstrapCommand class] bootstrapCommandLine]
                                                                            withString:@""];
 
     if (NO == [updatedContents isEqualToString:existingContents]) {

--- a/system7/Utils/Utils.h
+++ b/system7/Utils/Utils.h
@@ -18,6 +18,8 @@ int getConfig(GitRepository *repo, NSString *revision, S7Config * _Nullable __au
 
 int addLineToGitIgnore(NSString *lineToAppend);
 
+int installHook(NSString *hookName, NSString *commandLine, BOOL forceOverwrite, BOOL installFakeHooks);
+
 BOOL isExactlyOneBitSetInNumber(uint32_t bits);
 
 BOOL isCurrentDirectoryS7RepoRoot(void);

--- a/system7/Utils/Utils.m
+++ b/system7/Utils/Utils.m
@@ -7,6 +7,7 @@
 //
 
 #import "Utils.h"
+#import "S7BootstrapCommand.h"
 
 int executeInDirectory(NSString *directory, int (NS_NOESCAPE ^block)(void)) {
     NSString *cwd = [[NSFileManager defaultManager] currentDirectoryPath];
@@ -171,4 +172,107 @@ NSString *getGlobalGitConfigValue(NSString *key) {
     }
     
     return [value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+}
+
+int installHook(NSString *hookName, NSString *commandLine, BOOL forceOverwrite, BOOL installFakeHooks) {
+    NSString *hookFilePath = [@".git/hooks" stringByAppendingPathComponent:hookName];
+
+    NSString *contentsToWrite = [NSString stringWithFormat:@"#!/bin/sh\n\n%@\n", commandLine];
+
+    if (NO == forceOverwrite && [NSFileManager.defaultManager fileExistsAtPath:hookFilePath]) {
+        NSString *existingContents = [[NSString alloc] initWithContentsOfFile:hookFilePath encoding:NSUTF8StringEncoding error:nil];
+        if (NO == [existingContents hasPrefix:@"#!/bin/sh\n"]) {
+            fprintf(stderr,
+                    "\033[31m"
+                    "hook %s already exists and it's not a shell script, so we cannot merge s7 call into it\n"
+                    "\033[0m",
+                    hookFilePath.fileSystemRepresentation);
+
+            return S7ExitCodeFileOperationFailed;
+        }
+
+        if ([existingContents containsString:commandLine]) {
+            return S7ExitCodeSuccess;
+        }
+
+        NSString *oldStyleS7HookContents = [NSString
+                                            stringWithFormat:
+                                            @"#!/bin/sh\n"
+                                            "/usr/local/bin/s7 %@-hook \"$@\" <&0",
+                                            hookName];
+        if (NO == [existingContents isEqualToString:oldStyleS7HookContents]) {
+            NSString *existingHookBody = [existingContents stringByReplacingOccurrencesOfString:@"#!/bin/sh\n"
+                                                                                     withString:@""];
+
+            // 'uninstall' bootstrap command
+            existingHookBody = [existingHookBody stringByReplacingOccurrencesOfString:[[S7BootstrapCommand class] bootstrapCommandLine]
+                                                                           withString:@""];
+
+            NSString *mergedHookContents = [NSString stringWithFormat:
+                                            @"#!/bin/sh\n"
+                                            "\n"
+                                            "%@\n"
+                                            "\n"
+                                            "%@",
+                                            commandLine,
+                                            existingHookBody];
+
+            contentsToWrite = mergedHookContents;
+        }
+    }
+
+    if (installFakeHooks) {
+        contentsToWrite = @"";
+    }
+
+    NSError *error = nil;
+    if (NO == [NSFileManager.defaultManager fileExistsAtPath:@".git/hooks"]) {
+        if (NO == [NSFileManager.defaultManager
+                   createDirectoryAtPath:@".git/hooks"
+                   withIntermediateDirectories:NO
+                   attributes:nil
+                   error:&error])
+        {
+            fprintf(stderr,
+                    "'.git/hooks' directory doesn't exist. Failed to create it. Error: %s\n",
+                    [[error description] cStringUsingEncoding:NSUTF8StringEncoding]);
+
+            return S7ExitCodeFileOperationFailed;
+        }
+    }
+
+    if (NO == [contentsToWrite writeToFile:hookFilePath atomically:YES encoding:NSUTF8StringEncoding error:&error]) {
+        fprintf(stderr,
+                "failed to save %s to disk. Error: %s\n",
+                hookFilePath.fileSystemRepresentation,
+                [[error description] cStringUsingEncoding:NSUTF8StringEncoding]);
+
+        return S7ExitCodeFileOperationFailed;
+    }
+
+    NSUInteger posixPermissions = [NSFileManager.defaultManager attributesOfItemAtPath:hookFilePath error:&error].filePosixPermissions;
+    if (error) {
+        fprintf(stderr,
+                "failed to read %s posix permissions. Error: %s\n",
+                hookFilePath.fileSystemRepresentation,
+                [[error description] cStringUsingEncoding:NSUTF8StringEncoding]);
+
+        return S7ExitCodeFileOperationFailed;
+    }
+
+    posixPermissions |= 0111;
+
+    if (NO == [NSFileManager.defaultManager setAttributes:@{ NSFilePosixPermissions : @(posixPermissions) }
+                                             ofItemAtPath:hookFilePath
+                                                    error:&error])
+    {
+        fprintf(stderr,
+                "failed to make hook %s executable. Error: %s\n",
+                hookFilePath.fileSystemRepresentation,
+                [[error description] cStringUsingEncoding:NSUTF8StringEncoding]);
+
+        return S7ExitCodeFileOperationFailed;
+    }
+
+    return S7ExitCodeSuccess;
 }

--- a/system7/main.m
+++ b/system7/main.m
@@ -17,6 +17,7 @@
 #import "S7StatusCommand.h"
 #import "S7ResetCommand.h"
 #import "S7CheckoutCommand.h"
+#import "S7BootstrapCommand.h"
 
 #import "S7PrePushHook.h"
 #import "S7PostCheckoutHook.h"
@@ -91,6 +92,7 @@ Class commandClassByName(NSString *commandName) {
             [S7StatusCommand class],
             [S7ResetCommand class],
             [S7CheckoutCommand class],
+            [S7BootstrapCommand class]
         ]];
 
         for (Class<S7Command> commandClass in commandClasses) {


### PR DESCRIPTION
Унес bootstrap в отдельную команду.
Во-первых, ушли из init-а неспецифичные для него кода.
Во-вторых, в init-е теперь нет страха в виде --bootstrap, который не обратен --no-bootstrap.

Все равно остался легкий налет размазанности бутстрапом по нескольким файлам. Удалением бутстрапа занимаются и в утилсах, и пост-чекаут хук, и все кому не лень. Пока не придумал (и ленюсь думать) хорошее решение для этой фигни.