### PR TITLE
fix subrepos not in sync and merge commit failure on simple merge tha…

### DIFF
--- a/system7-tests/integration/case-mergeUpdatingSubstateAtOneSideDoesntFail.sh
+++ b/system7-tests/integration/case-mergeUpdatingSubstateAtOneSideDoesntFail.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+git clone github/rd2 pastey/rd2
+
+cd pastey/rd2
+
+assert s7 init
+assert git add .
+assert git commit -m "\"init s7\""
+
+assert s7 add --stage Dependencies/ReaddleLib '"$S7_ROOT/github/ReaddleLib"'
+
+pushd Dependencies/ReaddleLib > /dev/null
+  echo sqrt > RDMath.h
+  git add RDMath.h
+  git commit -m"add RDMath.h"
+popd > /dev/null
+
+assert s7 rebind --stage
+
+echo master > main.m
+git add main.m
+
+assert git commit -am '"add ReaddleLib subrepo"'
+
+
+echo
+git checkout -b experiment
+
+echo experiment > main.m
+
+assert git commit -am '"experiment in main.m"'
+
+echo
+git switch master
+
+pushd Dependencies/ReaddleLib > /dev/null
+  echo log2 >> RDMath.h
+  git commit -am"add more math fun"
+popd > /dev/null
+
+assert s7 rebind --stage
+assert git commit -am '"up ReaddleLib"'
+
+
+echo
+git switch experiment
+
+git merge --no-edit master
+
+assert test 0 -eq $?
+
+cmp .s7substate .s7control
+assert test 0 -eq $? # subrepos must be in sync
+
+assert grep '"sqrt"' Dependencies/ReaddleLib/RDMath.h > /dev/null
+assert grep '"log2"' Dependencies/ReaddleLib/RDMath.h > /dev/null

--- a/system7-tests/integration/case22-mergeConflict-checkoutSubreposUsage.sh
+++ b/system7-tests/integration/case22-mergeConflict-checkoutSubreposUsage.sh
@@ -59,9 +59,15 @@ cmp .s7substate .s7control
 assert test 0 -ne $? # subrepos not in sync
 assert test sqrt = `cat Dependencies/ReaddleLib/RDMath.h`
 
+grep '"experiment"' Dependencies/ReaddleLib/RDMath.h > /dev/null
+assert test 0 -ne $? # subrepo was not updated, thus doesn't contain 'experiment'
 
-# manually update subrepos
-assert s7 checkout
+echo
+echo "resolve conflict in favour of our changes"
+
+echo other > main.m
+git add main.m
+assert git commit -am'"finalize merge"'
 
 # now ReaddleLib must be up-to-date
 assert cmp .s7substate .s7control # now, must be in sync

--- a/system7-tests/integration/case24-mergeAfterGitResetWontPass.sh
+++ b/system7-tests/integration/case24-mergeAfterGitResetWontPass.sh
@@ -33,11 +33,17 @@ cd rd2
 
 git checkout -b experiment
 
-echo experiment > file
-git add file
-git commit -m"experiment"
+pushd Dependencies/ReaddleLib > /dev/null
+  echo faster-sqrt > RDMath.h
+  git add RDMath.h
+  git commit -m"faster sqrt"
+popd > /dev/null
+
+assert s7 rebind --stage
+assert git commit -m '"up ReaddleLib"'
 
 git push -u origin experiment
+
 
 cd "$S7_ROOT/pastey/rd2"
 
@@ -49,4 +55,5 @@ git checkout $PRE_READDLE_LIB_TIMES
 git reset --hard $MODERN_TIMES
 
 git merge --no-ff --no-edit origin/experiment
-assert test 0 -ne $?
+assert test -d Dependencies/ReaddleLib
+assert test faster-sqrt = `cat Dependencies/ReaddleLib/RDMath.h`

--- a/system7/Hooks/S7PostCheckoutHook.m
+++ b/system7/Hooks/S7PostCheckoutHook.m
@@ -160,14 +160,13 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
                       toConfig:(S7Config *)toConfig
                          clean:(BOOL)clean
 {
-    NSDictionary<NSString *, S7SubrepoDescription *> *subreposToAdd = nil;
     NSDictionary<NSString *, S7SubrepoDescription *> *subreposToDelete = nil;
-    NSDictionary<NSString *, S7SubrepoDescription *> *subreposToUpdate = nil;
+    NSDictionary<NSString *, S7SubrepoDescription *> *dummy = nil;
     diffConfigs(fromConfig,
                 toConfig,
                 &subreposToDelete,
-                &subreposToUpdate,
-                &subreposToAdd);
+                &dummy,
+                &dummy);
 
     int exitCode = S7ExitCodeSuccess;
 

--- a/system7/Hooks/S7PrepareCommitMsgHook.m
+++ b/system7/Hooks/S7PrepareCommitMsgHook.m
@@ -81,75 +81,9 @@
         }
 
         return [postRevertConfig saveToFileAtPath:S7ControlFileName];
-
     }
 
-    const BOOL isMergeCommit = [arguments containsObject:@"merge"];
-    if (NO == isMergeCommit) {
-        return 0;
-    }
-
-    if ([S7StatusCommand areSubreposInSync]) {
-        return 0;
-    }
-
-    // In 'post-merge' hook we rely on .s7control. We decide which subrepos to update, calculating
-    // diff between .s7control and .s7substate.
-    //
-    // If control is not in sync with the main config, then the result of subrepos checkout would be
-    // unpredictable. One possible scenario:
-    //
-    //   git checkout REV_20            # .s7control and .s7substate would be in sync
-    //   git reset --hard REV_100500    # .s7control left from REV_20
-    //   git merge something            # trouble...
-    //
-    //
-    // I don't think we have the right to update subrepos automatically in this hook:
-    //  1. it means that developer hasn't checked the result of what he's committing
-    //  2. doing such task in pre-commit hook just doesn't feel right to me
-    //
-
-    fprintf(stderr,
-            "\033[31m"
-            "Subrepos not in sync.\n"
-            "This might be the result of:\n"
-            " - conflicting merge\n"
-            " - git reset\n"
-            "\n"
-            "This commit may result in undefined subrepos state.\n"
-            "\n"
-            "How to recover:\n"
-            "\n"
-            " Case 1:   I didn't perform `git reset REV`. It was `git merge`/`git pull`\n"
-            "           that failed due to conflicts.\n"
-            "\n"
-            " Solution: run `s7 checkout`. It would sync subrepos.\n"
-            "           After that you'll be able to commit.\n"
-            "           S7 didn't run it automatically as no git-hooks are called\n"
-            "           in case of merge conflict.\n"
-            "\n"
-            "\n"
-            " Case 2:   I DID run `git reset REV` to \"checkout\" a different revision\n"
-            "           and then ran `git merge`/`git pull`.\n"
-            "\n"
-            " Solution: you'd have to rollback this merge and return to the clean REV.\n"
-            "           If you used `git reset --hard REV` before, then you can use it\n"
-            "           once again. After that, run `s7 checkout`\n"
-            "\n"
-            "           I would recommend to reset local changes and checkout\n"
-            "           a REV you want to in a proper way – using `git checkout REV`\n"
-            "           (optionally, with '-b <branch-name>')\n"
-            "           If you use `git checkout`, then s7 will checkout subrepos\n"
-            "           automatically.\n"
-            "\n"
-            "           After you have clean REV and subrepos are in sync, you can\n"
-            "           merge what you were trying to merge\n"
-            "\n"
-            "You can always check if subrepos are in sync, using `s7 status`.\n"
-            "\033[0m");
-
-    // hook exit code is not propagated as git command exit code,
-    // so there's no need or sense to return special S7ExitCode here
-    return 1;
+    return 0;
 }
+
 @end


### PR DESCRIPTION
…t updates .s7substate at one side

Намедни к нам обратился Жека. У него случилось очень печальное поведение s7 при очень простом мерже. Ему написали, что сабрепы not in sync, что он негодяй, и чтобы разбирался. Ну мы и стали разбираться.

Дано:
1. ветка Жеки, где он не трогал сабрепы
2. ветка, которую он хочет себе подмержить. На ней трогались сабрепы

Жека мержится. Конфликтов нет, и ничто не предвещает беды, но вызывается наш prepare-commit-msg, сравнивает .s7substate с .s7control, и молвит человеческим голосом, что,– "ты, Евгений, че с сабрепами наделал? Почему у тебя not in sync? Иди подними сабрепы, а потом коммить". И при этом еще прибрехивает в этом сообщении, что "у тебя конфликт при мерже видать был".

Сравнение в prepare-commit-msg было написано в угаре борьбы с ~~ветряными мельницами~~ потенциальными проблемами после использования rebase. Путем умственных экспериментов и перечитывания кодов s7, я понял, что эта борьба не совсем актуальна, и, по крайней мере, часть сценариев, которых я боялся, на самом деле нормально обработается.