### PR TITLE
Improve output

### DIFF
--- a/system7-tests/deinitTests.m
+++ b/system7-tests/deinitTests.m
@@ -24,7 +24,7 @@
     self.env = [[TestReposEnvironment alloc] initWithTestCaseName:self.className];
 }
 
-void assertRepoAtPWDIsFreeFromS7() {
+void assertRepoAtPWDIsFreeFromS7(void) {
     NSFileManager *fileManager = NSFileManager.defaultManager;
     XCTAssertFalse([fileManager fileExistsAtPath:S7BakFileName]);
     XCTAssertFalse([fileManager fileExistsAtPath:S7BootstrapFileName]);

--- a/system7/Hooks/S7PostCheckoutHook.m
+++ b/system7/Hooks/S7PostCheckoutHook.m
@@ -599,7 +599,7 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
 
     if (NO == [subrepoGit isRevisionAvailableLocally:expectedSubrepoStateDesc.revision]) {
         fprintf(stdout,
-                "\033[34m  >\033[0m fetching '%s'\n",
+                "  fetching '%s'\n",
                 [expectedSubrepoStateDesc.path fileSystemRepresentation]);
 
         if (0 != [subrepoGit fetch]) {

--- a/system7/Hooks/S7PostCheckoutHook.m
+++ b/system7/Hooks/S7PostCheckoutHook.m
@@ -269,6 +269,10 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
     for (S7SubrepoDescription *subrepoDesc in subreposToCheckout) {
         GitRepository *subrepoGit = subrepoDescToGit[subrepoDesc];
 
+        fprintf(stdout,
+                "\033[34m>\033[0m \033[1mchecking out subrepo '%s'\033[0m\n",
+                [subrepoDesc.path fileSystemRepresentation]);
+
         if (subrepoGit) {
             BOOL subrepoUrlChanged = NO;
             NSString *oldUrl = nil;
@@ -384,7 +388,7 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
                 }
             }
 
-            fprintf(stdout, "removing subrepo '%s'\n", subrepoPath.fileSystemRepresentation);
+            fprintf(stdout, "\033[31m>\033[0m \033[1mremoving subrepo '%s'\033[0m\n", subrepoPath.fileSystemRepresentation);
 
             NSError *error = nil;
             if (NO == [NSFileManager.defaultManager removeItemAtPath:subrepoPath error:&error]) {
@@ -415,10 +419,6 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
 
         BOOL isDirectory = NO;
         if ([NSFileManager.defaultManager fileExistsAtPath:subrepoDesc.path isDirectory:&isDirectory] && isDirectory) {
-            fprintf(stdout,
-                    " \033[34m==>\033[0m \033[1mchecking out subrepo '%s'\033[0m\n",
-                    [subrepoDesc.path fileSystemRepresentation]);
-
             GitRepository *subrepoGit = [[GitRepository alloc] initWithRepoPath:subrepoDesc.path];
             if (nil == subrepoGit) {
                 [corruptedSubrepoRepositoryIndices addIndex:i];
@@ -463,7 +463,7 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
                 // use fprintf in synchronized to make sure output of several parallel operation doesn't get mixed
                 fprintf(stderr,
                         "\033[31m"
-                        " uncommited local changes in subrepo '%s'\n"
+                        "  uncommited local changes in subrepo '%s'\n"
                         "\033[0m",
                         subrepoDesc.path.fileSystemRepresentation);
 
@@ -476,7 +476,7 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
                 @synchronized (self) {
                     fprintf(stderr,
                             "\033[31m"
-                            " failed to discard uncommited changes in subrepo '%s'\n"
+                            "  failed to discard uncommited changes in subrepo '%s'\n"
                             "\033[0m",
                             subrepoDesc.path.fileSystemRepresentation);
 
@@ -529,7 +529,7 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
             NSAssert(NO, @"");
             fprintf(stderr,
                     "\033[31m"
-                    " unexpected subrepo '%s' state. Failed to detect current branch.\n"
+                    "  unexpected subrepo '%s' state. Failed to detect current branch.\n"
                     "\033[0m",
                     expectedSubrepoStateDesc.path.fileSystemRepresentation);
             return S7ExitCodeGitOperationFailed;
@@ -599,7 +599,7 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
 
     if (NO == [subrepoGit isRevisionAvailableLocally:expectedSubrepoStateDesc.revision]) {
         fprintf(stdout,
-                " fetching '%s'\n",
+                "\033[34m  >\033[0m fetching '%s'\n",
                 [expectedSubrepoStateDesc.path fileSystemRepresentation]);
 
         if (0 != [subrepoGit fetch]) {
@@ -609,7 +609,7 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
         if (NO == [subrepoGit isRevisionAvailableLocally:expectedSubrepoStateDesc.revision]) {
             fprintf(stderr,
                     "\033[31m"
-                    " revision '%s' does not exist in '%s'\n"
+                    "  revision '%s' does not exist in '%s'\n"
                     "\033[0m",
                     [expectedSubrepoStateDesc.revision cStringUsingEncoding:NSUTF8StringEncoding],
                     [expectedSubrepoStateDesc.path fileSystemRepresentation]);
@@ -618,43 +618,25 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
         }
     }
 
-    BOOL shouldCheckout = NO;
-    if ([subrepoGit doesBranchExist:[@"origin/" stringByAppendingString:expectedSubrepoStateDesc.branch]]) {
-        if (0 != [subrepoGit checkoutRemoteTrackingBranch:expectedSubrepoStateDesc.branch]) {
-            return S7ExitCodeGitOperationFailed;
-        }
+    fprintf(stdout,
+            "  switching to %s\n",
+            [expectedSubrepoStateDesc.humanReadableRevisionAndBranchState cStringUsingEncoding:NSUTF8StringEncoding]);
 
-        NSString *currentBranchHeadRevision = nil;
-        if (0 != [subrepoGit getCurrentRevision:&currentBranchHeadRevision]) {
-            return S7ExitCodeGitOperationFailed;
-        }
-
-        if (NO == [expectedSubrepoStateDesc.revision isEqualToString:currentBranchHeadRevision]) {
-            shouldCheckout = YES;
-        }
-    }
-    else {
-        shouldCheckout = YES;
+    // `git checkout -B branch revision`
+    // this also makes checkout recursive if subrepo is a S7 repo itself
+    if (0 != [subrepoGit forceCheckoutLocalBranch:expectedSubrepoStateDesc.branch revision:expectedSubrepoStateDesc.revision]) {
+        // TODO: raise flag and complain
     }
 
-    if (shouldCheckout) {
-        fprintf(stdout,
-                " checkout '%s' to %s\n",
-                expectedSubrepoStateDesc.path.fileSystemRepresentation,
-                [expectedSubrepoStateDesc.humanReadableRevisionAndBranchState cStringUsingEncoding:NSUTF8StringEncoding]);
+    const BOOL configFileExists = isS7Repo(subrepoGit);
+    const BOOL controlFileExists = [NSFileManager.defaultManager fileExistsAtPath:[subrepoGit.absolutePath stringByAppendingPathComponent:S7ControlFileName]];
+    if (configFileExists && NO == controlFileExists) {
+        // handling the case when a nested subrepo is added to an existing subrepo
+        *shouldInitSubrepo = YES;
+    }
 
-        // `git checkout -B branch revision`
-        // this also makes checkout recursive if subrepo is a S7 repo itself
-        if (0 != [subrepoGit forceCheckoutLocalBranch:expectedSubrepoStateDesc.branch revision:expectedSubrepoStateDesc.revision]) {
-            // TODO: raise flag and complain
-        }
-
-        const BOOL configFileExists = isS7Repo(subrepoGit);
-        const BOOL controlFileExists = [NSFileManager.defaultManager fileExistsAtPath:[subrepoGit.absolutePath stringByAppendingPathComponent:S7ControlFileName]];
-        if (configFileExists && NO == controlFileExists) {
-            // handling the case when a nested subrepo is added to an existing subrepo
-            *shouldInitSubrepo = YES;
-        }
+    if (0 != [subrepoGit ensureBranchIsTrackingCorrespondingRemoteBranchIfItExists:expectedSubrepoStateDesc.branch]) {
+        return S7ExitCodeGitOperationFailed;
     }
 
     [self warnAboutDetachingIfNeeded:currentRevision subrepoDesc:expectedSubrepoStateDesc subrepoGit:subrepoGit];
@@ -664,8 +646,7 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
 
 + (int)cloneSubrepo:(S7SubrepoDescription *)subrepoDesc subrepoGit:(GitRepository **)ppSubrepoGit {
     fprintf(stdout,
-            " cloning subrepo '%s' from '%s'\n",
-            [subrepoDesc.path fileSystemRepresentation],
+            "  cloning from '%s'\n",
             [subrepoDesc.url fileSystemRepresentation]);
 
     int cloneExitStatus = 0;
@@ -690,7 +671,7 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
         if (nil == subrepoGit || 0 != cloneExitStatus) {
             fprintf(stderr,
                     "\033[31m"
-                    " failed to clone subrepo '%s'\n"
+                    "  failed to clone subrepo '%s'\n"
                     "\033[0m",
                     [subrepoDesc.path fileSystemRepresentation]);
             return S7ExitCodeGitOperationFailed;

--- a/system7/Hooks/S7PostCheckoutHook.m
+++ b/system7/Hooks/S7PostCheckoutHook.m
@@ -625,7 +625,7 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
     // `git checkout -B branch revision`
     // this also makes checkout recursive if subrepo is a S7 repo itself
     if (0 != [subrepoGit forceCheckoutLocalBranch:expectedSubrepoStateDesc.branch revision:expectedSubrepoStateDesc.revision]) {
-        // TODO: raise flag and complain
+        return S7ExitCodeGitOperationFailed;
     }
 
     const BOOL configFileExists = isS7Repo(subrepoGit);

--- a/system7/Ini Parser/S7IniConfig.h
+++ b/system7/Ini Parser/S7IniConfig.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 
-+ (instancetype)configWithContentsOfFile:(NSString *)filePath;
++ (nullable instancetype)configWithContentsOfFile:(NSString *)filePath;
 + (instancetype)configWithContentsOfString:(NSString *)string;
 
 @property (nonatomic, readonly, strong) NSDictionary<NSString *, NSDictionary<NSString *, NSString *> *> *dictionaryRepresentation;

--- a/system7/git/Git.h
+++ b/system7/git/Git.h
@@ -53,6 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (int)checkoutNewLocalBranch:(NSString *)branchName;
 - (int)checkoutExistingLocalBranch:(NSString *)branchName;
 - (int)checkoutRemoteTrackingBranch:(NSString *)branchName;
+- (int)ensureBranchIsTrackingCorrespondingRemoteBranchIfItExists:(NSString *)branchName;
 - (int)deleteLocalBranch:(NSString *)branchName;
 - (int)deleteRemoteBranch:(NSString *)branchName;
 - (int)forceCheckoutLocalBranch:(NSString *)branchName revision:(NSString *)revisions;

--- a/system7/git/Git.h
+++ b/system7/git/Git.h
@@ -81,7 +81,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                file:(nullable NSString *)file
                                          exitStatus:(int *)exitStatus;
 
-- (NSString *)showFile:(NSString *)filePath atRevision:(NSString *)revision exitStatus:(int *)exitStatus;
+- (nullable NSString *)showFile:(NSString *)filePath atRevision:(NSString *)revision exitStatus:(int *)exitStatus;
 
 - (BOOL)hasUncommitedChanges;
 

--- a/system7/git/Git.m
+++ b/system7/git/Git.m
@@ -965,6 +965,12 @@ static void (^_testRepoConfigureOnInitBlock)(GitRepository *);
         return getBranchExitStatus;
     }
 
+    if (nil == currentBranchName) {
+        fprintf(stderr,
+                "failed to push. No current branch in the repository.\n");
+        return S7ExitCodeGitOperationFailed;
+    }
+
     return [self pushBranch:currentBranchName];
 }
 
@@ -1057,7 +1063,7 @@ static void (^_testRepoConfigureOnInitBlock)(GitRepository *);
     return result;
 }
 
-- (NSString *)showFile:(NSString *)filePath atRevision:(NSString *)revision exitStatus:(int *)exitStatus {
+- (nullable NSString *)showFile:(NSString *)filePath atRevision:(NSString *)revision exitStatus:(int *)exitStatus {
     NSString *fileContents = nil;
     NSString *devNull = nil;
     NSString *spell = [NSString stringWithFormat:@"%@:%@", revision, filePath];


### PR DESCRIPTION
В процессе работы над этими изм-ми я обновил Xcode, и он подкинул пару новых ошибок компиляции и анализатора. По ходу прокомментирую.

Основная цель ПР-а – улучшить вывод при чекауте. Видимо в процессе ускорений/рефакторингов вывод строки " ==> checking out <repo>" попал в метод, который... собственно не занимается чекаутом, а делал подготовительную работу, из-за этого вывод был чуть странный.

Пока переносил "checking out" в нужное место заодно улучшил (на свой вкус) общий вид вывода при чекауте. Заменил "==>" на просто ">", поровнял другие строки под ">", чуть причесал местами вординг.

Параллельно увидел еще одно место, где был написан не самый оптимальный способ чек-аута. Об этом подробнее напишу по месту, где это происходило.