### PR TITLE
Add ability to specify S7 options

### DIFF
--- a/system7-tests/Utils/TestReposEnvironment.h
+++ b/system7-tests/Utils/TestReposEnvironment.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "S7Options.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -32,6 +33,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, strong) GitRepository *nikRd2Repo;
 
 - (GitRepository *)initializeRemoteRepoAtRelativePath:(NSString *)relativePath;
+
+- (GitRepository *)initializeLocalRepoAtRelativePath:(NSString *)relativePath
+                 addCommandAllowedTransportProtocols:(NSSet<S7OptionsTransportProtocolName> *)allowedTransportProtocols;
 
 - (void)touch:(NSString *)filePath;
 - (void)makeDir:(NSString *)filePath;

--- a/system7-tests/addTests.m
+++ b/system7-tests/addTests.m
@@ -111,7 +111,7 @@
         XCTAssertEqual(0, cloneExitStatus);
 
         S7AddCommand *command = [S7AddCommand new];
-        XCTAssertEqual(S7ExitCodeGitOperationFailed, [command runWithArguments:@[ @"Dependencies/ReaddleLib" ]]);
+        XCTAssertEqual(S7ExitCodeInvalidArgument, [command runWithArguments:@[ @"Dependencies/ReaddleLib" ]]);
     });
 }
 

--- a/system7-tests/addTests.m
+++ b/system7-tests/addTests.m
@@ -95,6 +95,52 @@
     });
 }
 
+- (void)testAddAlreadyClonedRepoWithNotAllowedTransportProtocol {
+    GitRepository *localRepo = [self.env initializeLocalRepoAtRelativePath:@"user/projects/rd2"
+                                       addCommandAllowedTransportProtocols:[NSSet setWithObject:S7OptionsTransportProtocolNameSSH]];
+    
+    executeInDirectory(localRepo.absolutePath, ^int {
+        s7init_deactivateHooks();
+
+        int cloneExitStatus = 0;
+        GitRepository *readdleLibRepo = [GitRepository
+                                         cloneRepoAtURL:self.env.githubReaddleLibRepo.absolutePath
+                                         destinationPath:@"Dependencies/ReaddleLib"
+                                         exitStatus:&cloneExitStatus];
+        XCTAssertNotNil(readdleLibRepo);
+        XCTAssertEqual(0, cloneExitStatus);
+
+        S7AddCommand *command = [S7AddCommand new];
+        XCTAssertEqual(S7ExitCodeGitOperationFailed, [command runWithArguments:@[ @"Dependencies/ReaddleLib" ]]);
+    });
+}
+
+- (void)testAddRepoWithURLWhichDoesNotMatchAllowedTransportProtocol {
+    GitRepository *localRepo = [self.env initializeLocalRepoAtRelativePath:@"user/projects/rd2"
+                                       addCommandAllowedTransportProtocols:[NSSet setWithObject:S7OptionsTransportProtocolNameSSH]];
+    
+    executeInDirectory(localRepo.absolutePath, ^int {
+        s7init_deactivateHooks();
+
+        S7AddCommand *command = [S7AddCommand new];
+        const int addResult = [command runWithArguments:@[ @"Dependencies/ReaddleLib", self.env.githubReaddleLibRepo.absolutePath ]];
+        XCTAssertEqual(S7ExitCodeInvalidArgument, addResult);
+    });
+}
+
+- (void)testAddRepoWithURLWhichMatchesAllowedTransportProtocol {
+    GitRepository *localRepo = [self.env initializeLocalRepoAtRelativePath:@"user/projects/rd2"
+                                       addCommandAllowedTransportProtocols:[NSSet setWithObject:S7OptionsTransportProtocolNameLocal]];
+    
+    executeInDirectory(localRepo.absolutePath, ^int {
+        s7init_deactivateHooks();
+
+        S7AddCommand *command = [S7AddCommand new];
+        const int addResult = [command runWithArguments:@[ @"Dependencies/ReaddleLib", self.env.githubReaddleLibRepo.absolutePath ]];
+        XCTAssertEqual(0, addResult);
+    });
+}
+
 - (void)testAddRepoWithUrlAndPath {
     executeInDirectory(self.env.pasteyRd2Repo.absolutePath, ^int {
         s7init_deactivateHooks();

--- a/system7-tests/optionsParsingTests.m
+++ b/system7-tests/optionsParsingTests.m
@@ -1,0 +1,206 @@
+//
+//  optionsParsingTests.m
+//  optionsParsingTests
+//
+//  Created by Andrew Podrugin on 01.10.2021.
+//  Copyright © 2021 Readdle. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "S7IniConfig.h"
+#import "S7Options.h"
+
+@interface optionsParsingTests : XCTestCase
+
+@end
+
+@implementation optionsParsingTests
+
+- (void)testCorrectAllowedTransportProtocolsListParsing {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = ssh, git"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    NSSet<S7OptionsTransportProtocolName> *expectedTransportProtocols =
+    [NSSet setWithObjects:S7OptionsTransportProtocolNameSSH, S7OptionsTransportProtocolNameGit, nil];
+    
+    XCTAssertEqualObjects(options.allowedTransportProtocols, expectedTransportProtocols);
+}
+
+- (void)testCorrectAllowedTransportProtocolsListWithOneProtocolParsing {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = ssh"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    NSSet<S7OptionsTransportProtocolName> *expectedTransportProtocols =
+    [NSSet setWithObjects:S7OptionsTransportProtocolNameSSH, nil];
+    
+    XCTAssertEqualObjects(options.allowedTransportProtocols, expectedTransportProtocols);
+}
+
+- (void)testCaseInsensitivityInAllowedTransportProtocolsListParsing {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = SsH, gIt, HtTpS"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    NSSet<S7OptionsTransportProtocolName> *expectedTransportProtocols = [NSSet setWithObjects:
+                                                                         S7OptionsTransportProtocolNameSSH,
+                                                                         S7OptionsTransportProtocolNameGit,
+                                                                         S7OptionsTransportProtocolNameHTTPS,
+                                                                         nil];
+    
+    XCTAssertEqualObjects(options.allowedTransportProtocols, expectedTransportProtocols);
+}
+
+- (void)testMissedAddSectionInAllowedTransportProtocolsListParsing {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:@"transport-protocols = git"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    
+    XCTAssertEqualObjects(options.allowedTransportProtocols, S7Options.supportedTransportProtocols);
+}
+
+- (void)testMissedOptionInAllowedTransportProtocolsListParsing {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:@"[add]"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    
+    XCTAssertEqualObjects(options.allowedTransportProtocols, S7Options.supportedTransportProtocols);
+}
+
+- (void)testMissedOptionValueInAllowedTransportProtocolsListParsing {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols ="];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    
+    XCTAssertEqualObjects(options.allowedTransportProtocols, S7Options.supportedTransportProtocols);
+}
+
+- (void)testInvalidSeparatorInAllowedTransportProtocolsListParsing {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = ssh | git.https"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    
+    XCTAssertEqualObjects(options.allowedTransportProtocols, S7Options.supportedTransportProtocols);
+}
+
+- (void)testInvalidProtocolInAllowedTransportProtocolsListParsing {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = ssh, kaka"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    
+    XCTAssertEqualObjects(options.allowedTransportProtocols, S7Options.supportedTransportProtocols);
+}
+
+- (void)testLocalURLMatching {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = local"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    NSString *localURLString = @"file://path/to/repo.git/";
+    
+    XCTAssertTrue([options urlStringMatchesAllowedTransportProtocols:localURLString]);
+}
+
+- (void)testLocalURLWithAbsolutePathMatching {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = local"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    NSString *localURLString = @"/path/to/repo.git/";
+    
+    XCTAssertTrue([options urlStringMatchesAllowedTransportProtocols:localURLString]);
+}
+
+- (void)testLocalURLWithRelativePathMatching {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = local"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    NSString *localURLString = @"./path/to/repo.git/";
+    
+    XCTAssertTrue([options urlStringMatchesAllowedTransportProtocols:localURLString]);
+}
+
+- (void)testLocalURLWithRelativeParentPathMatching {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = local"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    NSString *localURLString = @"../path/to/repo.git/";
+    
+    XCTAssertTrue([options urlStringMatchesAllowedTransportProtocols:localURLString]);
+}
+
+- (void)testSSHURLMatching {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = ssh"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    NSString *sshURLString = @"ssh://user@host.xz/path/to/repo.git/";
+    
+    XCTAssertTrue([options urlStringMatchesAllowedTransportProtocols:sshURLString]);
+}
+
+- (void)testSSHURLInSCPLikeFormatMatching {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = ssh"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    NSString *sshURLString = @"user@host.xz:path/to/repo.git/";
+    
+    XCTAssertTrue([options urlStringMatchesAllowedTransportProtocols:sshURLString]);
+}
+
+- (void)testSSHURLInSCPLikeFormatAndUserNameExpansionMatching {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = ssh"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    NSString *sshURLString = @"host.xz:/~user/path/to/repo.git/";
+    
+    XCTAssertTrue([options urlStringMatchesAllowedTransportProtocols:sshURLString]);
+}
+
+- (void)testGitURLMatching {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = git"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    NSString *gitURLString = @"git://host.xz/~user/path/to/repo.git/";
+    
+    XCTAssertTrue([options urlStringMatchesAllowedTransportProtocols:gitURLString]);
+}
+
+- (void)testHTTPURLMatching {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = http"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    NSString *httpURLString = @"http://host.xz/path/to/repo.git/";
+    
+    XCTAssertTrue([options urlStringMatchesAllowedTransportProtocols:httpURLString]);
+}
+
+- (void)testHTTPSURLMatching {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = https"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    NSString *httpURLString = @"https://host.xz/path/to/repo.git/";
+    
+    XCTAssertTrue([options urlStringMatchesAllowedTransportProtocols:httpURLString]);
+}
+
+- (void)testURLWithNotAllowedTransportProtocol {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = http, https, git"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    NSString *sshURLString = @"github.com:/~user/path/to/repo.git/";
+    
+    XCTAssertFalse([options urlStringMatchesAllowedTransportProtocols:sshURLString]);
+}
+
+@end

--- a/system7-tests/optionsParsingTests.m
+++ b/system7-tests/optionsParsingTests.m
@@ -203,4 +203,14 @@
     XCTAssertFalse([options urlStringMatchesAllowedTransportProtocols:sshURLString]);
 }
 
+- (void)testHTTPSURLDoesNotMatchSSHTransportProtocol {
+    S7IniConfig *config = [S7IniConfig configWithContentsOfString:
+                           @"[add]\n"
+                           "transport-protocols = ssh"];
+    S7Options *options = [[S7Options alloc] initWithIniConfig:config];
+    NSString *httpsURLString = @"https://user@host.xz/path/to/repo.git/";
+    
+    XCTAssertFalse([options urlStringMatchesAllowedTransportProtocols:httpsURLString]);
+}
+
 @end

--- a/system7.xcodeproj/project.pbxproj
+++ b/system7.xcodeproj/project.pbxproj
@@ -9,6 +9,9 @@
 /* Begin PBXBuildFile section */
 		2465939C24CA336700EFC5A0 /* HelpPager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2465939B24CA336700EFC5A0 /* HelpPager.m */; };
 		24689D5D24D1C914004DDB91 /* HelpPager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2465939B24CA336700EFC5A0 /* HelpPager.m */; };
+		6D73D3B1270702D0009AE0B9 /* S7Options.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D73D3B0270702D0009AE0B9 /* S7Options.m */; };
+		6D73D3B327070E9A009AE0B9 /* optionsParsingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D73D3B227070E9A009AE0B9 /* optionsParsingTests.m */; };
+		6D73D3B42707121F009AE0B9 /* S7Options.m in Sources */ = {isa = PBXBuildFile; fileRef = 6D73D3B0270702D0009AE0B9 /* S7Options.m */; };
 		BE0173E124864DF300BA4B2F /* resetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BE0173E024864DF300BA4B2F /* resetTests.m */; };
 		BE0173E424864EBF00BA4B2F /* S7ResetCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = BE0173E324864EBF00BA4B2F /* S7ResetCommand.m */; };
 		BE0173E524864EBF00BA4B2F /* S7ResetCommand.m in Sources */ = {isa = PBXBuildFile; fileRef = BE0173E324864EBF00BA4B2F /* S7ResetCommand.m */; };
@@ -96,6 +99,9 @@
 /* Begin PBXFileReference section */
 		2465939A24CA336700EFC5A0 /* HelpPager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HelpPager.h; sourceTree = "<group>"; };
 		2465939B24CA336700EFC5A0 /* HelpPager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HelpPager.m; sourceTree = "<group>"; };
+		6D73D3AF270702D0009AE0B9 /* S7Options.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = S7Options.h; sourceTree = "<group>"; };
+		6D73D3B0270702D0009AE0B9 /* S7Options.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = S7Options.m; sourceTree = "<group>"; };
+		6D73D3B227070E9A009AE0B9 /* optionsParsingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = optionsParsingTests.m; path = "system7-tests/optionsParsingTests.m"; sourceTree = SOURCE_ROOT; };
 		BE0173E024864DF300BA4B2F /* resetTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = resetTests.m; sourceTree = "<group>"; };
 		BE0173E224864EBF00BA4B2F /* S7ResetCommand.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = S7ResetCommand.h; sourceTree = "<group>"; };
 		BE0173E324864EBF00BA4B2F /* S7ResetCommand.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = S7ResetCommand.m; sourceTree = "<group>"; };
@@ -276,6 +282,7 @@
 				BE82188A2452C1DE00E878A8 /* Info.plist */,
 				BE38910524616A4100394CA8 /* S7Tests.pch */,
 				BE8218882452C1DE00E878A8 /* configParserTests.m */,
+				6D73D3B227070E9A009AE0B9 /* optionsParsingTests.m */,
 				BEBD16942455824400E81673 /* diffTests.m */,
 				BE3A29F124607234004A2B31 /* initTests.m */,
 				BEFAF7A025718AB7000D90C3 /* bootstrapTests.m */,
@@ -350,6 +357,8 @@
 				BE1079BF2466C557002A2A45 /* S7SubrepoDescription.m */,
 				BE82187F2452C16A00E878A8 /* S7Config.h */,
 				BE8218802452C16A00E878A8 /* S7Config.m */,
+				6D73D3AF270702D0009AE0B9 /* S7Options.h */,
+				6D73D3B0270702D0009AE0B9 /* S7Options.m */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -464,6 +473,7 @@
 				BED36BE0246D8A1700D6EB1C /* S7PostCheckoutHook.m in Sources */,
 				BEE928A12456DA6500BD6B86 /* Git.m in Sources */,
 				BE3A29EF2460712F004A2B31 /* S7InitCommand.m in Sources */,
+				6D73D3B1270702D0009AE0B9 /* S7Options.m in Sources */,
 				BE50AA00246C2CB800DBB618 /* S7PrePushHook.m in Sources */,
 				BEE672C82523B72200DB09BC /* S7IniConfig.m in Sources */,
 				BED36BEA246E904E00D6EB1C /* S7PostMergeHook.m in Sources */,
@@ -499,6 +509,7 @@
 				BE172C4924642C3B00B57557 /* mergeTests.m in Sources */,
 				BED60FB6245AB8F9008EA752 /* S7AddCommand.m in Sources */,
 				BE3A29F424607419004A2B31 /* addTests.m in Sources */,
+				6D73D3B327070E9A009AE0B9 /* optionsParsingTests.m in Sources */,
 				BE0173E124864DF300BA4B2F /* resetTests.m in Sources */,
 				BE5B752F248947AD008E7378 /* S7PrepareCommitMsgHook.m in Sources */,
 				BE3A29EC2460616D004A2B31 /* TestReposEnvironment.m in Sources */,
@@ -520,6 +531,7 @@
 				BE172CD324657CA700B57557 /* S7Diff.m in Sources */,
 				BED36BEB246E904E00D6EB1C /* S7PostMergeHook.m in Sources */,
 				BE90D391258F470900186E86 /* S7BootstrapCommand.m in Sources */,
+				6D73D3B42707121F009AE0B9 /* S7Options.m in Sources */,
 				BED36BE3246D8A4B00D6EB1C /* postCheckoutHookTests.m in Sources */,
 				BE1079BD2466C516002A2A45 /* S7SubrepoDescriptionConflict.m in Sources */,
 				BE4BB43C24615CFD00545358 /* rebindTests.m in Sources */,
@@ -703,7 +715,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.readdle.system7-tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -722,7 +734,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.15;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.readdle.system7-tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};

--- a/system7/Commands/S7AddCommand.m
+++ b/system7/Commands/S7AddCommand.m
@@ -144,7 +144,7 @@ NS_ASSUME_NONNULL_BEGIN
         
         if (nil != options && NO == [options urlStringMatchesAllowedTransportProtocols:url]) {
             fprintf(stderr,
-                    "URL '%s' does not match allowed transport protocols: %s.\n",
+                    "URL '%s' does not match allowed transport protocol(s): %s.\n",
                     [url cStringUsingEncoding:NSUTF8StringEncoding],
                     [[options.allowedTransportProtocols.allObjects componentsJoinedByString:@", "]
                      cStringUsingEncoding:NSUTF8StringEncoding]);
@@ -188,7 +188,7 @@ NS_ASSUME_NONNULL_BEGIN
         
         if (nil != options && NO == [options urlStringMatchesAllowedTransportProtocols:actualRemoteUrl]) {
             fprintf(stderr,
-                    "cloned subrepo URL '%s' does not match allowed transport protocols: %s.\n",
+                    "cloned subrepo URL '%s' does not match allowed transport protocol(s): %s.\n",
                     [actualRemoteUrl cStringUsingEncoding:NSUTF8StringEncoding],
                     [[options.allowedTransportProtocols.allObjects componentsJoinedByString:@", "]
                      cStringUsingEncoding:NSUTF8StringEncoding]);

--- a/system7/Commands/S7AddCommand.m
+++ b/system7/Commands/S7AddCommand.m
@@ -192,7 +192,7 @@ NS_ASSUME_NONNULL_BEGIN
                     [actualRemoteUrl cStringUsingEncoding:NSUTF8StringEncoding],
                     [[options.allowedTransportProtocols.allObjects componentsJoinedByString:@", "]
                      cStringUsingEncoding:NSUTF8StringEncoding]);
-            return S7ExitCodeGitOperationFailed;
+            return S7ExitCodeInvalidArgument;
         }
 
         if (nil == url) {

--- a/system7/Commands/S7AddCommand.m
+++ b/system7/Commands/S7AddCommand.m
@@ -8,6 +8,7 @@
 
 #import "S7AddCommand.h"
 #import "S7Config.h"
+#import "S7Options.h"
 #import "Git.h"
 #import "Utils.h"
 #import "S7InitCommand.h"
@@ -126,12 +127,27 @@ NS_ASSUME_NONNULL_BEGIN
         }
     }
 
+    S7Options *options = nil;
+    
+    if ([[NSFileManager defaultManager] fileExistsAtPath:S7OptionsFileName]) {
+        options = [[S7Options alloc] initWithContentsOfFile:S7OptionsFileName];
+    }
+    
     GitRepository *gitSubrepo = nil;
 
     BOOL isDirectory = NO;
     if (NO == [[NSFileManager defaultManager] fileExistsAtPath:path isDirectory:&isDirectory]) {
         if (0 == url.length) {
             NSLog(@"ERROR: failed to add subrepo. Non-empty url expected.");
+            return S7ExitCodeInvalidArgument;
+        }
+        
+        if (nil != options && NO == [options urlStringMatchesAllowedTransportProtocols:url]) {
+            fprintf(stderr,
+                    "URL '%s' does not match allowed transport protocols: %s.\n",
+                    [url cStringUsingEncoding:NSUTF8StringEncoding],
+                    [[options.allowedTransportProtocols.allObjects componentsJoinedByString:@", "]
+                     cStringUsingEncoding:NSUTF8StringEncoding]);
             return S7ExitCodeInvalidArgument;
         }
 
@@ -167,6 +183,15 @@ NS_ASSUME_NONNULL_BEGIN
 
         NSString *actualRemoteUrl = nil;
         if (0 != [gitSubrepo getUrl:&actualRemoteUrl]) {
+            return S7ExitCodeGitOperationFailed;
+        }
+        
+        if (nil != options && NO == [options urlStringMatchesAllowedTransportProtocols:actualRemoteUrl]) {
+            fprintf(stderr,
+                    "cloned subrepo URL '%s' does not match allowed transport protocols: %s.\n",
+                    [actualRemoteUrl cStringUsingEncoding:NSUTF8StringEncoding],
+                    [[options.allowedTransportProtocols.allObjects componentsJoinedByString:@", "]
+                     cStringUsingEncoding:NSUTF8StringEncoding]);
             return S7ExitCodeGitOperationFailed;
         }
 

--- a/system7/Types/S7Options.h
+++ b/system7/Types/S7Options.h
@@ -1,0 +1,42 @@
+//
+//  S7Options.h
+//  S7Options
+//
+//  Created by Andrew Podrugin on 01.10.2021.
+//  Copyright © 2021 Readdle. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class S7IniConfig;
+
+// apodrugin@readdle.com
+// Actually git also supports FTP/FTPS protocols, but they are deprecated
+// (see https://git-scm.com/docs/git-clone#_git_urls). Thus these protocols
+// are omitted in list.
+typedef NSString *S7OptionsTransportProtocolName NS_EXTENSIBLE_STRING_ENUM;
+extern S7OptionsTransportProtocolName const S7OptionsTransportProtocolNameLocal;
+extern S7OptionsTransportProtocolName const S7OptionsTransportProtocolNameSSH;
+extern S7OptionsTransportProtocolName const S7OptionsTransportProtocolNameGit;
+extern S7OptionsTransportProtocolName const S7OptionsTransportProtocolNameHTTP;
+extern S7OptionsTransportProtocolName const S7OptionsTransportProtocolNameHTTPS;
+
+@interface S7Options : NSObject
+
+@property (nonatomic, readonly) NSSet<S7OptionsTransportProtocolName> *allowedTransportProtocols;
+
+@property (nonatomic, class, readonly) NSSet<S7OptionsTransportProtocolName> *supportedTransportProtocols;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+
+- (nullable instancetype)initWithContentsOfFile:(NSString *)filePath;
+- (nullable instancetype)initWithIniConfig:(S7IniConfig *)iniConfig NS_DESIGNATED_INITIALIZER;
+
+- (BOOL)urlStringMatchesAllowedTransportProtocols:(NSString *)urlString;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/system7/Types/S7Options.m
+++ b/system7/Types/S7Options.m
@@ -155,14 +155,23 @@ static BOOL isSSHURLString(NSString *urlString) {
     if (urlStringHasScheme(urlString, @"ssh")) {
         return YES;
     }
+    
+    const NSUInteger schemeSeparatorLocation = [urlString rangeOfString:@"://"].location;
+    
+    if (NSNotFound != schemeSeparatorLocation) {
+        return NO;
+    }
 
-    const NSInteger firstColonIndex = [urlString rangeOfString:@":"].location;
+    const NSUInteger firstColonIndex = [urlString rangeOfString:@":"].location;
     
     if (NSNotFound == firstColonIndex) {
         return NO;
     }
     
-    return NSNotFound == [urlString rangeOfString:@"/" options:0 range:NSMakeRange(0, firstColonIndex)].location;
+    const NSUInteger slashLocationBeforeColon =
+    [urlString rangeOfString:@"/" options:0 range:NSMakeRange(0, firstColonIndex)].location;
+    
+    return NSNotFound == slashLocationBeforeColon;
 }
 
 static BOOL isGitURLString(NSString *urlString) {

--- a/system7/Types/S7Options.m
+++ b/system7/Types/S7Options.m
@@ -113,7 +113,11 @@ static NSString * const S7OptionsAddCommandAllowedTransportProtocols = @"transpo
             [errorMessage appendFormat:@" '%@'", protocol];
         }
         
-        fprintf(stderr, "%s\n", [errorMessage cStringUsingEncoding:NSUTF8StringEncoding]);
+        fprintf(stderr,
+                "\033[31m"
+                "%s\n"
+                "\033[0m",
+                [errorMessage cStringUsingEncoding:NSUTF8StringEncoding]);
         _allowedTransportProtocols = self.class.supportedTransportProtocols;
         return _allowedTransportProtocols;
     }

--- a/system7/Types/S7Options.m
+++ b/system7/Types/S7Options.m
@@ -1,0 +1,188 @@
+//
+//  S7Options.m
+//  S7Options
+//
+//  Created by Andrew Podrugin on 01.10.2021.
+//  Copyright © 2021 Readdle. All rights reserved.
+//
+
+#import "S7Options.h"
+#import "S7IniConfig.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+S7OptionsTransportProtocolName const S7OptionsTransportProtocolNameLocal = @"local";
+S7OptionsTransportProtocolName const S7OptionsTransportProtocolNameSSH = @"ssh";
+S7OptionsTransportProtocolName const S7OptionsTransportProtocolNameGit = @"git";
+S7OptionsTransportProtocolName const S7OptionsTransportProtocolNameHTTP = @"http";
+S7OptionsTransportProtocolName const S7OptionsTransportProtocolNameHTTPS = @"https";
+
+static NSString * const S7OptionsAddCommandSectionName = @"add";
+static NSString * const S7OptionsAddCommandAllowedTransportProtocols = @"transport-protocols";
+
+
+@interface S7Options()
+
+@property (nonatomic, readonly) S7IniConfig *iniConfig;
+
+@end
+
+@implementation S7Options
+
+#pragma mark - Synthesizers -
+
+@synthesize allowedTransportProtocols = _allowedTransportProtocols;
+
+#pragma mark - Initialization -
+
+- (nullable instancetype)initWithContentsOfFile:(NSString *)filePath {
+    if (0 == filePath.length) {
+        NSParameterAssert(filePath.length > 0);
+        return nil;
+    }
+    
+    S7IniConfig *iniConfig = [S7IniConfig configWithContentsOfFile:filePath];
+    
+    return [self initWithIniConfig:iniConfig];
+}
+
+- (nullable instancetype)initWithIniConfig:(S7IniConfig *)iniConfig {
+    if (nil == iniConfig) {
+        NSParameterAssert(nil != iniConfig);
+        return nil;
+    }
+    
+    if (nil == (self = [super init])) {
+        return nil;
+    }
+ 
+    _iniConfig = iniConfig;
+    
+    return self;
+}
+
+#pragma mark - Properties -
+
++ (NSSet<S7OptionsTransportProtocolName> *)supportedTransportProtocols {
+    static NSSet<S7OptionsTransportProtocolName> *supportedTransportProtocols = nil;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        supportedTransportProtocols = [NSSet setWithObjects:
+                                       S7OptionsTransportProtocolNameLocal,
+                                       S7OptionsTransportProtocolNameSSH,
+                                       S7OptionsTransportProtocolNameGit,
+                                       S7OptionsTransportProtocolNameHTTP,
+                                       S7OptionsTransportProtocolNameHTTPS,
+                                       nil];
+    });
+    
+    return supportedTransportProtocols;
+}
+
+- (NSSet<S7OptionsTransportProtocolName> *)allowedTransportProtocols {
+    if (nil != _allowedTransportProtocols) {
+        return _allowedTransportProtocols;
+    }
+    
+    NSDictionary<NSString *, NSDictionary<NSString *, NSString *> *> *iniDict = self.iniConfig.dictionaryRepresentation;
+    NSString *allowedProtocolsString = iniDict[S7OptionsAddCommandSectionName][S7OptionsAddCommandAllowedTransportProtocols].lowercaseString;
+    NSString *trimmedAllowedProtocolsString = [allowedProtocolsString stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet];
+    NSArray<NSString *> *components = [trimmedAllowedProtocolsString componentsSeparatedByString:@","];
+    
+    if (0 == components.count) {
+        _allowedTransportProtocols = self.class.supportedTransportProtocols;
+        return _allowedTransportProtocols;
+    }
+    
+    NSMutableArray<S7OptionsTransportProtocolName> *protocols = [NSMutableArray arrayWithCapacity:components.count];
+    
+    for (NSString *component in components) {
+        [protocols addObject:[component stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet]];
+    }
+    
+    NSMutableSet<S7OptionsTransportProtocolName> *unexpectedProtocols = [NSMutableSet setWithArray:protocols];
+        
+    [unexpectedProtocols minusSet:self.class.supportedTransportProtocols];
+    if (unexpectedProtocols.count > 0) {
+        NSMutableString *errorMessage =
+        [NSMutableString stringWithFormat:@"error: unsupported transport protocol(s) detected during '%@' option parsing:",
+         S7OptionsAddCommandAllowedTransportProtocols];
+        
+        for (S7OptionsTransportProtocolName protocol in unexpectedProtocols) {
+            [errorMessage appendFormat:@" '%@'", protocol];
+        }
+        
+        fprintf(stderr, "%s\n", [errorMessage cStringUsingEncoding:NSUTF8StringEncoding]);
+        _allowedTransportProtocols = self.class.supportedTransportProtocols;
+        return _allowedTransportProtocols;
+    }
+    
+    _allowedTransportProtocols = [NSSet setWithArray:protocols];
+    return _allowedTransportProtocols;
+}
+
+- (BOOL)urlStringMatchesAllowedTransportProtocols:(NSString *)urlString {
+    NSDictionary<S7OptionsTransportProtocolName, NSValue *> *protocolToMethodMap =
+    @{
+        S7OptionsTransportProtocolNameLocal : [NSValue valueWithPointer:isLocalURLString],
+        S7OptionsTransportProtocolNameSSH : [NSValue valueWithPointer:isSSHURLString],
+        S7OptionsTransportProtocolNameGit : [NSValue valueWithPointer:isGitURLString],
+        S7OptionsTransportProtocolNameHTTP : [NSValue valueWithPointer:isHTTPURLString],
+        S7OptionsTransportProtocolNameHTTPS : [NSValue valueWithPointer:isHTTPSURLString]
+    };
+    
+    for (S7OptionsTransportProtocolName protocol in self.allowedTransportProtocols) {
+        BOOL (*urlStringMatchesProtocol)(NSString *) = [protocolToMethodMap[protocol] pointerValue];
+
+        if (urlStringMatchesProtocol(urlString)) {
+            return YES;
+        }
+    }
+    
+    return NO;
+}
+
+static BOOL isLocalURLString(NSString *urlString) {
+    if (urlStringHasScheme(urlString, @"file")) {
+        return YES;
+    }
+    
+    return [urlString hasPrefix:@"/"] || [urlString hasPrefix:@"./"] || [urlString hasPrefix:@"../"];
+}
+
+static BOOL isSSHURLString(NSString *urlString) {
+    if (urlStringHasScheme(urlString, @"ssh")) {
+        return YES;
+    }
+
+    const NSInteger firstColonIndex = [urlString rangeOfString:@":"].location;
+    
+    if (NSNotFound == firstColonIndex) {
+        return NO;
+    }
+    
+    return NSNotFound == [urlString rangeOfString:@"/" options:0 range:NSMakeRange(0, firstColonIndex)].location;
+}
+
+static BOOL isGitURLString(NSString *urlString) {
+    return urlStringHasScheme(urlString, @"git");
+}
+
+static BOOL isHTTPURLString(NSString *urlString) {
+    return urlStringHasScheme(urlString, @"http");
+}
+
+static BOOL isHTTPSURLString(NSString *urlString) {
+    return urlStringHasScheme(urlString, @"https");
+}
+
+static BOOL urlStringHasScheme(NSString *urlString, NSString *scheme) {
+    NSURLComponents *components = [[NSURLComponents alloc] initWithString:urlString];
+    
+    return [components.scheme isEqual:scheme];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/system7/Types/S7Types.h
+++ b/system7/Types/S7Types.h
@@ -15,6 +15,7 @@ extern NSString * const S7ConfigFileName;
 extern NSString * const S7ControlFileName;
 extern NSString * const S7BakFileName;
 extern NSString * const S7BootstrapFileName;
+extern NSString * const S7OptionsFileName;
 
 typedef enum {
     S7ExitCodeSuccess = 0,

--- a/system7/Types/S7Types.m
+++ b/system7/Types/S7Types.m
@@ -12,3 +12,4 @@ NSString * const S7ConfigFileName = @".s7substate";
 NSString * const S7ControlFileName = @".s7control";
 NSString * const S7BakFileName = @".s7bak";
 NSString * const S7BootstrapFileName = @".s7bootstrap";
+NSString * const S7OptionsFileName = @".s7options";


### PR DESCRIPTION
Add ability to specify S7 options via .s7options file which may change S7 behaviour. Add first option to allow subrepos addition only with specific transport protocols.