### PR TITLE
fix failure to push in subrepo in specific case

### DIFF
--- a/system7-tests/integration/case-pushWithDeletedSubrepoRevisionAndRollback.sh
+++ b/system7-tests/integration/case-pushWithDeletedSubrepoRevisionAndRollback.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+cd "$S7_ROOT"
+
+git clone github/rd2 pastey/rd2
+
+cd pastey/rd2
+
+assert s7 init
+assert git add .
+assert git commit -m "\"init s7\""
+
+assert s7 add --stage Dependencies/ReaddleLib '"$S7_ROOT/github/ReaddleLib"'
+git commit -m"add subrepos"
+
+pushd Dependencies/ReaddleLib > /dev/null
+  ORIGINAL_COMMIT_IN_READDLE_LIB=$(git rev-parse --short HEAD)
+
+  echo "mult" > RDMath.h
+  git add RDMath.h
+  git commit -m"mult"
+popd > /dev/null
+
+assert s7 rebind --stage
+git commit -m"up ReaddleLib"
+
+assert git push
+
+# by a coincidense, make some bad commit in a subrepo and rebind it
+
+pushd Dependencies/ReaddleLib > /dev/null
+  echo "ooops" > RDMath.h
+  git add RDMath.h
+  git commit -m"bad commit"
+popd > /dev/null
+
+assert s7 rebind --stage
+git commit -m"up ReaddleLib (with bad commit)"
+
+# decide to burry the bad commit and rollback to an even older state of subrepo
+
+pushd Dependencies/ReaddleLib > /dev/null
+  git checkout -B master $ORIGINAL_COMMIT_IN_READDLE_LIB
+popd > /dev/null
+
+assert s7 rebind --stage
+git commit -m"up ReaddleLib (rollback)"
+
+assert git push
+

--- a/system7/Hooks/S7PrePushHook.m
+++ b/system7/Hooks/S7PrePushHook.m
@@ -369,6 +369,17 @@
                 continue;
             }
 
+            if (NO == [subrepoGit isRevision:subrepoDesc.revision knownAtLocalBranch:branch]) {
+                // See case-pushWithDeletedSubrepoRevisionAndRollback.sh for an example of
+                // situation where this check is important
+                //
+                fprintf(stdout,
+                        "\n  ⚠️  skipping push of %s as it's not referenced by the branch '%s' anymore\n",
+                        [subrepoDesc.revision cStringUsingEncoding:NSUTF8StringEncoding],
+                        [branch cStringUsingEncoding:NSUTF8StringEncoding]);
+                continue;
+            }
+
             [branchesToPush addObject:branch];
         }
 

--- a/system7/git/Git.h
+++ b/system7/git/Git.h
@@ -68,6 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (int)getLatestRemoteRevision:(NSString * _Nullable __autoreleasing * _Nonnull)ppRevision atBranch:(NSString *)branchName;
 - (BOOL)isRevisionAvailableLocally:(NSString *)revision;
 - (BOOL)isRevisionDetached:(NSString *)revision numberOfOrphanedCommits:(int *)pNumberOfOrphanedCommits;
+- (BOOL)isRevision:(NSString *)revision knownAtLocalBranch:(NSString *)branchName;
 - (BOOL)isRevision:(NSString *)revision knownAtRemoteBranch:(NSString *)branchName;
 - (BOOL)isRevisionAnAncestor:(NSString *)possibleAncestor toRevision:(NSString *)possibleDescendant;
 - (BOOL)isMergeRevision:(NSString *)revision;


### PR DESCRIPTION
Наблюдал на днях у Егора картину. Он не мог запушить rd2, т.к. отказывалась пушиться сабрепа. В сабрепе он был на ревизии меньшей, чем была на сервере, ну и сервер ему говорил "куда прешь? non fast-forward!".

Его устраивало поднять эту сабрепу до origin/master. Так что сделали там pull, в rd2 rebind, и... получили такую же ошибку в другой сабрепе.

В другой сабрепе финт с пулом уже нас не устраивал, т.к. там есть кода, которые мы не готовы получить.

У меня не было тогда времени вникать как он пришел к такому состоянию. Мы отрубили pre-push, запычкались и пошли по своим делам.

Сегодня меня посетил один сценарий того, как можно прийти к описаной проблеме. См. case-pushWithDeletedSubrepoRevisionAndRollback.sh. Опишу тут человеческим языком:
1. делаем что-то в сабрепе. Ребайндим. Коммит записывается в .s7substate
2. решаем, что все не то. Идем в сабрепу и откатываемся на более старую ревизию. Т.е. локальная ветка смотрит на коммит раньше чем такая же ремоут ветка. Зачем и как Егор мог такое сделать – не знаю. Есть у меня теория, что это мог сделать даже не он сам, а `s7 co`. Он страдал с мержем, и несколько раз его делал/откатывал – может что-то такое и в порыве отчаяния делал.
3. делаем пуш в главной репе. s7 пробигается по истории коммитов .s7substate, и видит коммит из пункта 1. До моего фикса там была только проверка, что если коммита нет на сервере, то значит ветку надо пушить.

Это все наводит еще на мысли о текущей стратегии выбора какие ветки сабреп пушить. См. коммент в начале `S7PrePushHook.m`. Теоретически выглядит так, что если я сделаю в сабрепе ветку, сделаю ребайнд, потом убью эту ветку, то главная репа ее воскресит. Вроде бы нехорошо, но с другой стороны – в главной репе есть такая запись, так что если кто-то вернется на этот коммит главной репы, то он должен получить и сабрепу. Так что считаю, что все логично.