### PR TITLE
fetch subrepos with blob:none too to reduce disk usage and network

### DIFF
--- a/system7/git/Git.m
+++ b/system7/git/Git.m
@@ -940,7 +940,12 @@ static void (^_testRepoConfigureOnInitBlock)(GitRepository *);
 #pragma mark - exchange -
 
 - (int)fetch {
-    const int exitStatus = [self runGitCommand:@"fetch -p"
+    // pastey:
+    // use --filter=blob:none to reduce the size of the subrepos
+    // blob-less repos almost don't affect the day-to-day use of an average user
+    // Git will fetch needed blobs on demand
+    //
+    const int exitStatus = [self runGitCommand:@"fetch --filter=blob:none -p"
                                   stdOutOutput:NULL
                                   stdErrOutput:NULL];
     return exitStatus;


### PR DESCRIPTION
Добавил --filter=blob:none и в fetch.
Вижу, что размеры клонов на jenkins-ах растут.
Я пока наблюдаю только одно неудобство после введения blob:none – в Xcode-е местами не работает из коробки authors (blame). Из cli работает. Xcode видать юзает что-то свое (наверное gitlib), и не предусмотрели работу с blobless.
Что думаете?