### PR TITLE
fix tricky case when push of new branch failed because of failure to …

### DIFF
--- a/system7-tests/integration/case-pushOfNewBranchDoesntPushUnnecessarySubrepos.sh
+++ b/system7-tests/integration/case-pushOfNewBranchDoesntPushUnnecessarySubrepos.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+cd "$S7_ROOT"
+
+git clone github/rd2 pastey/rd2
+
+cd pastey/rd2
+
+assert s7 init
+assert git add .
+assert git commit -m "\"init s7\""
+
+assert s7 add --stage Dependencies/ReaddleLib '"$S7_ROOT/github/ReaddleLib"'
+assert s7 add --stage Dependencies/RDPDFKit '"$S7_ROOT/github/RDPDFKit"'
+git commit -m"add subrepos"
+
+git push
+
+
+# nik switches RDPDFKit to a different branch
+cd "$S7_ROOT/nik"
+
+git clone "$S7_ROOT/github/rd2"
+
+cd rd2
+
+pushd Dependencies/RDPDFKit > /dev/null
+  git checkout -b experiment
+  echo "experiment" >> RDPDFAnnotation.h
+  git add RDPDFAnnotation.h
+  git commit -m"annotation"
+popd > /dev/null
+
+assert s7 rebind --stage
+git commit -m"up RDPDFKit"
+
+git push
+
+
+# pastey gets these changes, and thus gets an "annotation" commit in RDPDFKit. Currently known only
+# at "experiment" branch
+cd "$S7_ROOT/pastey/rd2"
+git pull
+
+
+cd "$S7_ROOT/nik/rd2"
+
+pushd Dependencies/RDPDFKit > /dev/null
+  git switch master
+  git merge --ff --no-edit experiment
+popd > /dev/null
+
+assert s7 rebind --stage
+git commit -m"up RDPDFKit"
+
+assert git push
+
+
+
+# someone makes some upstream changes in RDPDFKit (maybe even me, but from a different clone)
+cd "$S7_ROOT/pastey"
+git clone "$S7_ROOT/github/RDPDFKit"
+cd RDPDFKit
+echo "AP/N" >> RDPDFAnnotation.h
+git add RDPDFAnnotation.h
+git commit -m"appearance streams"
+git push
+
+
+cd "$S7_ROOT/pastey/rd2"
+
+git pull
+git checkout -b new-branch
+
+pushd Dependencies/ReaddleLib > /dev/null
+  echo "mult" > RDMath.h
+  git add RDMath.h
+  git commit -m"mult"
+popd > /dev/null
+
+assert s7 rebind --stage
+git commit -m"up ReaddleLib"
+
+assert git push origin -u HEAD


### PR DESCRIPTION
…push unrelated (not changed) subrepo

Регулярно нарываюсь на то, что после мержа s7 пытается пычкать лишние репозитории, и в итоге не дает что-то запычкать.
В виде теста тут описан один сценарий.
В реальности я уверен, что есть еще один сценарий. Когда у меня в сабрепе есть коммит, но просто из-за того, что не делался `fetch`, то не обновлена ремоутная ветка – из-за этого `s7` думает, что коммита нет на ремоуте, и пытается делать пуш. Хоть убей не могу это воспроизвести искусственно, хоть и наблюдал не раз в реальности.

Этот фикс не идеален. Он правильный, но это не вся картина. Правильно было бы поправить алгорит вычисления того какие сабрепы надо пушить в `pre-push` хуке. Но там надо крепко думать. Проблема в том, что для новых веток Git знатно подсирает, и говорит хуку, что будем пычкать от сюда (HEAD), и до обеда (типа он не знает до куда). И приходится танцевать с бубном. Я для этого кейса изначально срезал угол, и там решение максимально простое, но не самое точное. На решение по красоте не имею сил.