### PR TITLE
Merge via intermediate branch

### DIFF
--- a/buildme.sh
+++ b/buildme.sh
@@ -29,7 +29,8 @@ xcodebuild_cmd() {
     # these headers are unwanted and may cause module import conflicts  
     unset USER_HEADER_SEARCH_PATHS
     unset HEADER_SEARCH_PATHS
-    xcodebuild -target system7 -configuration Release DSTROOT="$HOME" clean install
+    xcodebuild -target system7 -configuration Release clean
+    xcodebuild -target system7 -configuration Release DSTROOT="$HOME" install
 }
 
 if ! xcodebuild_cmd

--- a/system7/Merge Driver/S7ConfigMergeDriver.m
+++ b/system7/Merge Driver/S7ConfigMergeDriver.m
@@ -285,6 +285,22 @@ typedef enum {
         }
     }
 
+    NSString *resultingBranchName = conflictToMerge.ourVersion.branch;
+
+    const char *intermediateBranchNameCString = getenv("S7_MERGE_DRIVER_INTERMEDIATE_BRANCH");
+    if (intermediateBranchNameCString) {
+        NSString *intermediateBranchName = [[NSString alloc]
+                                            initWithCString:intermediateBranchNameCString
+                                            encoding:NSUTF8StringEncoding];
+
+        if (0 != [subrepoGit checkoutNewLocalBranch:intermediateBranchName]) {
+            *exitStatus = S7ExitCodeGitOperationFailed;
+            return conflictToMerge;
+        }
+
+        resultingBranchName = intermediateBranchName;
+    }
+
     if (0 != [subrepoGit mergeWith:theirRevision]) {
         *exitStatus = S7ExitCodeGitOperationFailed;
         return conflictToMerge;
@@ -299,7 +315,7 @@ typedef enum {
     return [[S7SubrepoDescription alloc] initWithPath:subrepoPath
                                                   url:conflictToMerge.ourVersion.url
                                              revision:mergeRevision
-                                               branch:conflictToMerge.ourVersion.branch];
+                                               branch:resultingBranchName];
 }
 
 - (int)mergeRepo:(GitRepository *)repo

--- a/system7/git/Git.m
+++ b/system7/git/Git.m
@@ -804,19 +804,12 @@ static void (^_testRepoConfigureOnInitBlock)(GitRepository *);
     NSParameterAssert(40 == possibleAncestor.length);
     NSParameterAssert(40 == possibleDescendant.length);
 
-    NSString *stdOutOutput = nil;
-    const int exitStatus = [self runGitCommand:[NSString stringWithFormat:@"merge-base %@ %@", possibleAncestor, possibleDescendant]
-                                  stdOutOutput:&stdOutOutput
+    const int exitStatus = [self runGitCommand:[NSString stringWithFormat:@"merge-base --is-ancestor %@ %@",
+                                                possibleAncestor,
+                                                possibleDescendant]
+                                  stdOutOutput:NULL
                                   stdErrOutput:NULL];
-    if (0 != exitStatus) {
-        NSAssert(NO, @"");
-        return NO;
-    }
-
-    NSString *mergeBaseRevision = [stdOutOutput stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-    NSAssert(40 == mergeBaseRevision.length, @"");
-
-    return [possibleAncestor isEqualToString:mergeBaseRevision];
+    return 0 == exitStatus;
 }
 
 - (BOOL)isCurrentRevisionMerge {

--- a/system7/main.m
+++ b/system7/main.m
@@ -81,8 +81,16 @@ void printHelp(void) {
     help_puts("    output (if any), and git return code.");
     help_puts("");
     help_puts(" S7_MERGE_DRIVER_RESPONSE");
-    help_puts("    Specifis response that automates s7 merge driver. Options are the same as");
+    help_puts("    Specific response that automates s7 merge driver. Options are the same as");
     help_puts("    driver's prompt input: (m)erge, keep (l)ocal or keep (r)emote.");
+    help_puts(" S7_MERGE_DRIVER_INTERMEDIATE_BRANCH");
+    help_puts("    If this option is set and user chooses (m)erge resolution. Then the merge is");
+    help_puts("    performed not directly to the <local>, but an intermediate branch named");
+    help_puts("    with the value from S7_MERGE_DRIVER_INTERMEDIATE_BRANCH is created from <local> state,");
+    help_puts("    and the actual merge is done to an intermediate branch.");
+    help_puts("    This is necessary if direct push to the <local> branch is restricted by the protection rules");
+    help_puts("    at Git hosting system. User will then create a PR from S7_MERGE_DRIVER_INTERMEDIATE_BRANCH");
+    help_puts("    to the branch from <local>.");
 }
 
 Class commandClassByName(NSString *commandName) {


### PR DESCRIPTION
Интерактивные вопросы при мерже разосшедшихся ревизий в сабрепах вдохновлялись HG.
В наших современных реалиях чаще всего не имеем права мержить (а главное пушить) напрямую в таргет ветку.
Завел переменную окружения, которую будет читать мерж драйвер, и если она есть, то перед мержем будет создаваться промежуточная мерж-ветка.
Например:
```
S7_MERGE_DRIVER_INTERMEDIATE_BRANCH=merge/release/pdfexpert-7.19.0/to/release/pdfexpert-next git merge origin/release/pdfexpert-7.19.0
```

Кроме собственно этой фичи в этом ПР два маленьких фикса. Будут описаны по дифу.