### PR TITLE
fix concurrent use of cwd during checkout

### DIFF
--- a/system7-tests/initTests.m
+++ b/system7-tests/initTests.m
@@ -42,56 +42,21 @@
     executeInDirectory(self.env.pasteyRd2Repo.absolutePath, ^int{
         S7InitCommand *command = [S7InitCommand new];
         XCTAssertEqual(0, [command runWithArguments:@[]]);
-
-        BOOL isDirectory = NO;
-        XCTAssertTrue([NSFileManager.defaultManager fileExistsAtPath:S7ConfigFileName isDirectory:&isDirectory]);
-        XCTAssertFalse(isDirectory);
-
-        XCTAssertTrue([NSFileManager.defaultManager fileExistsAtPath:S7ControlFileName isDirectory:&isDirectory]);
-        XCTAssertFalse(isDirectory);
-
-        XCTAssertTrue([NSFileManager.defaultManager fileExistsAtPath:@".gitignore" isDirectory:&isDirectory]);
-        XCTAssertFalse(isDirectory);
-
-        NSString *gitignoreContents = [NSString stringWithContentsOfFile:@".gitignore" encoding:NSUTF8StringEncoding error:nil];
-        XCTAssertTrue(gitignoreContents.length > 0);
-        XCTAssertNotEqual([gitignoreContents rangeOfString:S7ControlFileName].location, NSNotFound);
-        XCTAssertEqual([gitignoreContents rangeOfString:S7ControlFileName options:NSBackwardsSearch].location,
-                       [gitignoreContents rangeOfString:S7ControlFileName].location,
-                       @"must be added to .gitignore just once");
-
-        XCTAssertTrue([NSFileManager.defaultManager fileExistsAtPath:S7ControlFileName isDirectory:&isDirectory]);
-        XCTAssertFalse(isDirectory);
-
-        S7Config *config = [[S7Config alloc] initWithContentsOfFile:S7ConfigFileName];
-        XCTAssertNotNil(config);
-        S7Config *controlConfig = [[S7Config alloc] initWithContentsOfFile:S7ControlFileName];
-        XCTAssertNotNil(controlConfig);
-        XCTAssertEqualObjects(config, controlConfig);
-
-        NSSet<Class<S7Hook>> *hookClasses = [NSSet setWithArray:@[
-            [S7PrePushHook class],
-            [S7PostCheckoutHook class],
-            [S7PostCommitHook class],
-            [S7PostMergeHook class],
-        ]];
-
-        for (Class<S7Hook> hookClass in hookClasses) {
-            NSString *gitHookName = [hookClass gitHookName];
-            NSString *actualHookContents = [[NSString alloc]
-                                            initWithData:[NSFileManager.defaultManager contentsAtPath:[@".git/hooks" stringByAppendingPathComponent:gitHookName]]
-                                            encoding:NSUTF8StringEncoding];
-            NSString *expectedHookCallCommandPart = [NSString stringWithFormat:@"s7 %@-hook", gitHookName];
-            XCTAssertTrue([actualHookContents containsString:expectedHookCallCommandPart]);
-        }
-
-        NSString *configContents = [[NSString alloc]
-                                    initWithData:[NSFileManager.defaultManager contentsAtPath:@".git/config"]
-                                    encoding:NSUTF8StringEncoding];
-        XCTAssertTrue([configContents containsString:@"[merge \"s7\"]"]);
-        
         return S7ExitCodeSuccess;
     });
+
+    [self assertRepoAtPathHasAllProperSystemFiles:self.env.pasteyRd2Repo.absolutePath];
+}
+
+- (void)testOnVirginRepoWithADifferentWorkingDir {
+    // init pastey's repo with the working dir in nik's repo
+    executeInDirectory(self.env.nikRd2Repo.absolutePath, ^int{
+        S7InitCommand *command = [S7InitCommand new];
+        XCTAssertEqual(0, [command runWithArguments:@[] inRepo:self.env.pasteyRd2Repo]);
+        return S7ExitCodeSuccess;
+    });
+
+    [self assertRepoAtPathHasAllProperSystemFiles:self.env.pasteyRd2Repo.absolutePath];
 }
 
 - (void)testOnAlreadyInitializedRepo {
@@ -317,6 +282,70 @@
         S7InitCommand *command = [S7InitCommand new];
         XCTAssertEqual(0, [command runWithArguments:@[]]);
     }];
+}
+
+#pragma mark - assertions -
+
+- (void)assertRepoAtPathHasAllProperSystemFiles:(NSString *)absoluteRepoPath {
+    executeInDirectory(absoluteRepoPath, ^int{
+        BOOL isDirectory = NO;
+        XCTAssertTrue([NSFileManager.defaultManager fileExistsAtPath:S7ConfigFileName isDirectory:&isDirectory]);
+        XCTAssertFalse(isDirectory);
+        
+        XCTAssertTrue([NSFileManager.defaultManager fileExistsAtPath:S7ControlFileName isDirectory:&isDirectory]);
+        XCTAssertFalse(isDirectory);
+        
+        XCTAssertTrue([NSFileManager.defaultManager fileExistsAtPath:S7BootstrapFileName isDirectory:&isDirectory]);
+        XCTAssertFalse(isDirectory);
+
+        XCTAssertTrue([NSFileManager.defaultManager fileExistsAtPath:@".gitignore" isDirectory:&isDirectory]);
+        XCTAssertFalse(isDirectory);
+
+        NSString *gitignoreContents = [NSString stringWithContentsOfFile:@".gitignore" encoding:NSUTF8StringEncoding error:nil];
+        XCTAssertTrue(gitignoreContents.length > 0);
+        XCTAssertNotEqual([gitignoreContents rangeOfString:S7ControlFileName].location, NSNotFound);
+        XCTAssertEqual([gitignoreContents rangeOfString:S7ControlFileName options:NSBackwardsSearch].location,
+                       [gitignoreContents rangeOfString:S7ControlFileName].location,
+                       @"must be added to .gitignore just once");
+        
+        XCTAssertTrue([NSFileManager.defaultManager fileExistsAtPath:S7ControlFileName isDirectory:&isDirectory]);
+        XCTAssertFalse(isDirectory);
+        
+        S7Config *config = [[S7Config alloc] initWithContentsOfFile:S7ConfigFileName];
+        XCTAssertNotNil(config);
+        S7Config *controlConfig = [[S7Config alloc] initWithContentsOfFile:S7ControlFileName];
+        XCTAssertNotNil(controlConfig);
+        XCTAssertEqualObjects(config, controlConfig);
+        
+        NSSet<Class<S7Hook>> *hookClasses = [NSSet setWithArray:@[
+            [S7PrePushHook class],
+            [S7PostCheckoutHook class],
+            [S7PostCommitHook class],
+            [S7PostMergeHook class],
+        ]];
+        
+        for (Class<S7Hook> hookClass in hookClasses) {
+            NSString *gitHookName = [hookClass gitHookName];
+            NSString *actualHookContents = [[NSString alloc]
+                                            initWithData:[NSFileManager.defaultManager contentsAtPath:[@".git/hooks" stringByAppendingPathComponent:gitHookName]]
+                                            encoding:NSUTF8StringEncoding];
+            NSString *expectedHookCallCommandPart = [NSString stringWithFormat:@"s7 %@-hook", gitHookName];
+            XCTAssertTrue([actualHookContents containsString:expectedHookCallCommandPart]);
+        }
+        
+        NSString *configContents = [[NSString alloc]
+                                    initWithData:[NSFileManager.defaultManager contentsAtPath:@".git/config"]
+                                    encoding:NSUTF8StringEncoding];
+        XCTAssertTrue([configContents containsString:@"[merge \"s7\"]"]);
+
+        NSString *gitattributesContents = [[NSString alloc]
+                                           initWithData:[NSFileManager.defaultManager contentsAtPath:@".gitattributes"]
+                                           encoding:NSUTF8StringEncoding];
+        XCTAssertTrue([gitattributesContents containsString:@"merge=s7"]);
+        XCTAssertTrue([gitattributesContents containsString:@"filter=s7"]);
+
+        return 0;
+    });
 }
 
 @end

--- a/system7-tests/resetTests.m
+++ b/system7-tests/resetTests.m
@@ -404,7 +404,11 @@
     [self.env.pasteyRd2Repo run:^(GitRepository * _Nonnull repo) {
         s7init_deactivateHooks();
 
+        // add RDPDFKit twice to be sure that we also test dispatch_apply parallel work inside reset.
+        // If we have just one subrepo, then dispatch_apply is too smart and simply runs the only operation
+        // straight on the calling thread.
         s7add_stage(@"Dependencies/RDPDFKit", self.env.githubRDPDFKitRepo.absolutePath);
+        s7add_stage(@"Dependencies/RDPDFKit2", self.env.githubRDPDFKitRepo.absolutePath);
 
         GitRepository *formCalcSubrepoGit = [GitRepository repoAtPath:@"Dependencies/RDPDFKit/Dependencies/FormCalc"];
         XCTAssertNotNil(formCalcSubrepoGit);

--- a/system7/Commands/S7AddCommand.m
+++ b/system7/Commands/S7AddCommand.m
@@ -305,7 +305,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     // do this in transaction? all or nothing?
 
-    const int gitignoreAddResult = addLineToGitIgnore(path);
+    const int gitignoreAddResult = addLineToGitIgnore(repo, path);
     if (0 != gitignoreAddResult) {
         return gitignoreAddResult;
     }

--- a/system7/Commands/S7BootstrapCommand.m
+++ b/system7/Commands/S7BootstrapCommand.m
@@ -38,7 +38,16 @@ NS_ASSUME_NONNULL_BEGIN
         // we may still fail to install bootstrap, for example, if post-checkout hook exists
         // and it's not a shell script (where we can merge in)
         //
-        installHook(@"post-checkout", [[self class] bootstrapCommandLine], NO, NO);
+        GitRepository *repo = [GitRepository repoAtPath:@"."];
+        if (nil == repo) {
+            return S7ExitCodeNotGitRepository;
+        }
+
+        installHook(repo,
+                    @"post-checkout",
+                    [[self class] bootstrapCommandLine],
+                    NO,
+                    NO);
     }
 
     // according to https://git-scm.com/docs/gitattributes

--- a/system7/Commands/S7InitCommand.h
+++ b/system7/Commands/S7InitCommand.h
@@ -12,6 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface S7InitCommand : NSObject <S7Command>
 
+- (int)runWithArguments:(NSArray<NSString *> *)arguments inRepo:(GitRepository *)repo;
+
 @property (nonatomic, assign) BOOL installFakeHooks;
 
 @end

--- a/system7/Commands/S7InitCommand.m
+++ b/system7/Commands/S7InitCommand.m
@@ -100,6 +100,10 @@
 
 - (int)runWithArguments:(NSArray<NSString *> *)arguments {
     GitRepository *repo = [GitRepository repoAtPath:@"."];
+    return [self runWithArguments:arguments inRepo:repo];
+}
+
+- (int)runWithArguments:(NSArray<NSString *> *)arguments inRepo:(GitRepository *)repo {
     if (nil == repo) {
         return S7ExitCodeNotGitRepository;
     }
@@ -118,11 +122,14 @@
         }
     }
 
+    NSString *const absoluteRepoPath = repo.absolutePath;
+
+    NSString *const configFilePath = [absoluteRepoPath stringByAppendingPathComponent:S7ConfigFileName];
     BOOL isDirectory = NO;
-    const BOOL configFileExisted = [[NSFileManager defaultManager] fileExistsAtPath:S7ConfigFileName isDirectory:&isDirectory];
+    const BOOL configFileExisted = [[NSFileManager defaultManager] fileExistsAtPath:configFilePath isDirectory:&isDirectory];
     if (NO == configFileExisted) {
-        if (NO == [[NSFileManager defaultManager] createFileAtPath:S7ConfigFileName contents:nil attributes:nil]) {
-            logError("failed to create %s file\n", S7ConfigFileName.fileSystemRepresentation);
+        if (NO == [[NSFileManager defaultManager] createFileAtPath:configFilePath contents:nil attributes:nil]) {
+            logError("failed to create %s file\n", configFilePath.fileSystemRepresentation);
             return S7ExitCodeFileOperationFailed;
         }
     }
@@ -137,7 +144,7 @@
 
     int hookInstallationExitCode = 0;
     for (Class<S7Hook> hookClass in hookClasses) {
-        hookInstallationExitCode = [self installHook:hookClass];
+        hookInstallationExitCode = [self installHook:hookClass inRepo:repo];
         if (0 != hookInstallationExitCode) {
             logError("error: failed to install `%s` git hook\n",
                      [hookClass gitHookName].fileSystemRepresentation);
@@ -145,36 +152,37 @@
         }
     }
 
-    const int gitIgnoreUpdateExitCode = addLineToGitIgnore(S7ControlFileName);
+    const int gitIgnoreUpdateExitCode = addLineToGitIgnore(repo, S7ControlFileName);
     if (0 != gitIgnoreUpdateExitCode) {
         return gitIgnoreUpdateExitCode;
     }
 
-    if (0 != addLineToGitIgnore(S7BakFileName)) {
+    if (0 != addLineToGitIgnore(repo, S7BakFileName)) {
         return S7ExitCodeFileOperationFailed;
     }
 
-    const int configUpdateExitStatus = [self installS7ConfigMergeDriver];
+    const int configUpdateExitStatus = [self installS7ConfigMergeDriverInRepo:repo];
     if (0 != configUpdateExitStatus) {
         return configUpdateExitStatus;
     }
 
     if (createBootstrapFile) {
-        const int bootstrapFileCreationExitCode = [self createBootstrapFile];
+        const int bootstrapFileCreationExitCode = [self createBootstrapFileInRepo:repo];
         if (0 != bootstrapFileCreationExitCode) {
             return bootstrapFileCreationExitCode;
         }
     }
 
-    const BOOL controlFileExisted = [NSFileManager.defaultManager fileExistsAtPath:S7ControlFileName];
+    NSString *const controlFilePath = [absoluteRepoPath stringByAppendingPathComponent:S7ControlFileName];
+    const BOOL controlFileExisted = [NSFileManager.defaultManager fileExistsAtPath:controlFilePath];
     if (NO == controlFileExisted) {
         // create control file at the very end.
-        // existance of .s7control is used as an indicator that s7 repo
+        // existence of .s7control is used as an indicator that s7 repo
         // is well formed. No other command will run if there's no .s7control
         //
-        if (0 != [[S7Config emptyConfig] saveToFileAtPath:S7ControlFileName]) {
+        if (0 != [[S7Config emptyConfig] saveToFileAtPath:controlFilePath]) {
             logError("failed to save %s to disk.\n",
-                     S7ControlFileName.fileSystemRepresentation);
+                     controlFilePath.fileSystemRepresentation);
 
             return S7ExitCodeFileOperationFailed;
         }
@@ -213,23 +221,23 @@
     return S7ExitCodeSuccess;
 }
 
-- (int)installHook:(Class<S7Hook>)hookClass {
-    // there's no guarantie that s7 will be the only one citizen of a hook,
+- (int)installHook:(Class<S7Hook>)hookClass inRepo:(GitRepository *)repo {
+    // there's no guarantee that s7 will be the only one citizen of a hook,
     // thus we add " || exit $?" – to exit hook properly if s7 hook fails
     NSString *commandLine = [NSString
                              stringWithFormat:
                              @"/usr/local/bin/s7 %@-hook \"$@\" <&0 || exit $?",
                              [hookClass gitHookName]];
 
-    return installHook([hookClass gitHookName],commandLine, self.forceOverwriteHooks, self.installFakeHooks);
+    return installHook(repo, [hookClass gitHookName], commandLine, self.forceOverwriteHooks, self.installFakeHooks);
 }
 
-- (int)installS7ConfigMergeDriver {
+- (int)installS7ConfigMergeDriverInRepo:(GitRepository *)repo {
     if (self.installFakeHooks) {
         return 0;
     }
 
-    NSString *configFilePath = @".git/config";
+    NSString *configFilePath = [repo.absolutePath stringByAppendingPathComponent:@".git/config"];
 
     BOOL isDirectory = NO;
     if (NO == [[NSFileManager defaultManager] fileExistsAtPath:configFilePath isDirectory:&isDirectory]) {
@@ -276,7 +284,8 @@
         }
     }
 
-    const int gitattributesUpdateExitCode = addLineToGitAttributes([NSString stringWithFormat:@"%@ merge=s7", S7ConfigFileName]);
+    const int gitattributesUpdateExitCode = 
+        addLineToGitAttributes(repo, [NSString stringWithFormat:@"%@ merge=s7", S7ConfigFileName]);
     if (0 != gitattributesUpdateExitCode) {
         return gitattributesUpdateExitCode;
     }
@@ -284,12 +293,13 @@
     return 0;
 }
 
-- (int)createBootstrapFile {
+- (int)createBootstrapFileInRepo:(GitRepository *)repo {
     if (self.installFakeHooks) {
         return S7ExitCodeSuccess;
     }
 
-    const BOOL fileExisted = [[NSFileManager defaultManager] fileExistsAtPath:S7BootstrapFileName];
+    NSString *const bootstrapFilePath = [repo.absolutePath stringByAppendingPathComponent:S7BootstrapFileName];
+    const BOOL fileExisted = [[NSFileManager defaultManager] fileExistsAtPath:bootstrapFilePath];
     if (NO == fileExisted) {
         NSString *bootstrapFileContents =
         @"This file is used to automatically run `s7 init` when an existing s7 repo is cloned.\n"
@@ -334,72 +344,21 @@
          "    not the situation we want a user to deal with.\n"
          ;
 
-        if (NO == [[NSFileManager defaultManager] createFileAtPath:S7BootstrapFileName
+        if (NO == [[NSFileManager defaultManager] createFileAtPath:bootstrapFilePath
                                                           contents:[bootstrapFileContents dataUsingEncoding:NSUTF8StringEncoding]
                                                         attributes:nil]) {
-            logError("failed to create %s file\n", S7BootstrapFileName.fileSystemRepresentation);
+            logError("failed to create %s file\n", bootstrapFilePath.fileSystemRepresentation);
             return S7ExitCodeFileOperationFailed;
         }
     }
 
-    const int gitattributesUpdateExitCode = addLineToGitAttributes([NSString stringWithFormat:@"%@ filter=s7", S7BootstrapFileName]);
+    const int gitattributesUpdateExitCode = 
+        addLineToGitAttributes(repo, [NSString stringWithFormat:@"%@ filter=s7", S7BootstrapFileName]);
     if (0 != gitattributesUpdateExitCode) {
         return gitattributesUpdateExitCode;
     }
 
     return S7ExitCodeSuccess;
-}
-
-int addLineToGitAttributes(NSString *lineToAppend) {
-    static NSString *gitattributesFileName = @".gitattributes";
-
-    BOOL isDirectory = NO;
-    if (NO == [[NSFileManager defaultManager] fileExistsAtPath:gitattributesFileName isDirectory:&isDirectory]) {
-        if (NO == [[NSFileManager defaultManager]
-                   createFileAtPath:gitattributesFileName
-                   contents:nil
-                   attributes:nil])
-        {
-            logError("failed to create .gitattributes file\n");
-            return 1;
-        }
-    }
-
-    if (isDirectory) {
-        logError(".gitattributes is a directory!?\n");
-        return 2;
-    }
-
-    NSError *error = nil;
-    NSMutableString *newContent = [[NSMutableString alloc] initWithContentsOfFile:gitattributesFileName encoding:NSUTF8StringEncoding error:&error];
-    if (nil != error) {
-        logError("failed to read contents of .gitattributes file. Error: %s\n",
-                [[error description] cStringUsingEncoding:NSUTF8StringEncoding]);
-        return 3;
-    }
-
-    NSArray<NSString *> *existingGitattributeLines = [newContent componentsSeparatedByCharactersInSet:[NSCharacterSet newlineCharacterSet]];
-    if ([existingGitattributeLines containsObject:lineToAppend]) {
-        // do not add twice
-        return 0;
-    }
-
-    if (newContent.length > 0 && NO == [newContent hasSuffix:@"\n"]) {
-        [newContent appendString:@"\n"];
-    }
-
-    if (NO == [lineToAppend hasSuffix:@"\n"]) {
-        lineToAppend = [lineToAppend stringByAppendingString:@"\n"];
-    }
-    [newContent appendString:lineToAppend];
-
-    if (NO == [newContent writeToFile:gitattributesFileName atomically:YES encoding:NSUTF8StringEncoding error:&error] || nil != error) {
-        logError("failed to write contents of .gitattributes file. Error: %s\n",
-                [[error description] cStringUsingEncoding:NSUTF8StringEncoding]);
-        return 4;
-    }
-
-    return 0;
 }
 
 @end

--- a/system7/Hooks/S7PostCheckoutHook.m
+++ b/system7/Hooks/S7PostCheckoutHook.m
@@ -871,23 +871,16 @@ parentRepoAbsolutePath:(NSString *)parentRepoAbsolutePath
 + (int)initS7InSubrepos:(NSArray<GitRepository *> *)subrepos {
     int result = S7ExitCodeSuccess;
 
-    NSAssert(NSThread.isMainThread,
-             @"if someday this code gets parrallelized, we will have to remove `executeInDirectory` here."
-              "Different threads will mess with it, resulting in undefined (read bad) checkout/init results.");
-
     for (GitRepository *subrepoGit in subrepos) {
         NSAssert([NSFileManager.defaultManager fileExistsAtPath:[subrepoGit.absolutePath stringByAppendingPathComponent:S7ConfigFileName]], @"");
 
-        const int initExitStatus =
-        executeInDirectory(subrepoGit.absolutePath, ^int{
-            S7InitCommand *initCommand = [S7InitCommand new];
-            // do not automatically create .s7bootstrap in subrepos. This makes uncomitted local changes
-            // in subrepos. Especially inconvinient when you switch to some old revision.
-            // Let user decide which repo should contain .s7bootstrap, by explicit invocation of
-            // `s7 init` and add of .s7bootstap to the repo.
-            //
-            return [initCommand runWithArguments:@[ @"--no-bootstrap" ]];
-        });
+        S7InitCommand *initCommand = [S7InitCommand new];
+        // do not automatically create .s7bootstrap in subrepos. This makes uncommitted local changes
+        // in subrepos. Especially inconvenient when you switch to some old revision.
+        // Let user decide which repo should contain .s7bootstrap, by explicit invocation of
+        // `s7 init` and add of .s7bootstrap to the repo.
+        //
+        const int initExitStatus = [initCommand runWithArguments:@[ @"--no-bootstrap" ] inRepo:subrepoGit];
 
         if (0 != initExitStatus) {
             result = initExitStatus;

--- a/system7/Utils/Utils.h
+++ b/system7/Utils/Utils.h
@@ -16,12 +16,13 @@ int executeInDirectory(NSString *directory, int (NS_NOESCAPE ^block)(void));
 
 int getConfig(GitRepository *repo, NSString *revision, S7Config * _Nullable __autoreleasing * _Nonnull ppConfig);
 
-int addLineToGitIgnore(NSString *lineToAppend);
+int addLineToGitIgnore(GitRepository *repo, NSString *lineToAppend);
 int removeLinesFromGitIgnore(NSSet<NSString *> *linesToRemove);
 
+int addLineToGitAttributes(GitRepository *repo, NSString *lineToAppend);
 int removeFilesFromGitattributes(NSSet<NSString *> *filesToRemove);
 
-int installHook(NSString *hookName, NSString *commandLine, BOOL forceOverwrite, BOOL installFakeHooks);
+int installHook(GitRepository *repo, NSString *hookName, NSString *commandLine, BOOL forceOverwrite, BOOL installFakeHooks);
 
 BOOL isCurrentDirectoryS7RepoRoot(void);
 BOOL isS7Repo(GitRepository *repo);


### PR DESCRIPTION
При очередном мерже s7 упал на ассерте:
```
 NSAssert(NSThread.isMainThread,
             @"if someday this code gets parrallelized, we will have to remove `executeInDirectory` here."
              "Different threads will mess with it, resulting in undefined (read bad) checkout/init results.");
```

В процессе чекаута, если сабрепа сама является s7 репой, на ней делается дополнительный init. S7InitCommand был написан в те дивные времена, когда можно было взять текущую папку, и в ней работать со служебными файлами s7 и git-а. Когда я сделал checkout параллельным, я почему-то решил, что кейс с init-ом не может произойти параллельно, поэтому можно не трогать S7InitCommand, и не избавлять его от наивного использования CWD. Я оставлял этот ассерт чтобы если что отловить, если S7InitCommand таки юзается с разных потоков при параллельной работе чекаута. И вот оно меня нашло.

Самое интересное. На этот код есть тест, но в тесте ровно одна сабрепа с вложенной сабрепой. Как я сегодня узнал, `dispatch_apply` в случае одного элемента в массиве не порождает новых потоков, а просто выполняет одну итерацию прямо на вызвавшем потоке. Поэтому наш тест не тестировал реальной многопоточной работы checkout (на самом деле reset). Пропатчил тест, чтобы там было больше сабреп (целых две 😂 ).

Ну, а дальше собственно нужно было приучить S7InitCommand работать на абсолютных путях. Дописал соотв-й тест. Слегка усилил существующие проверки в тестах – не все куски кода оказались покрыты.

Я думаю, что именно из-за этого бага у нас периодически в `rdpdfkit-ui-tests-helpers` появлялись мистические .s7substate и прочее барахло. cc @aishchenko-readdle 