### PR TITLE
Bugfix/conflict resolution

### DIFF
--- a/system7-tests/configParserTests.m
+++ b/system7-tests/configParserTests.m
@@ -203,6 +203,30 @@
     XCTAssertEqualObjects(parsedConfig.subrepoDescriptions, expectedParsedConfig);
 }
 
+- (void)testConfigWithConflictOneSideRemoveWritesAndReadsBackFromDisk {
+    S7Config *originalConfig =
+    [[S7Config alloc]
+     initWithSubrepoDescriptions:@[
+            [[S7SubrepoDescriptionConflict alloc]
+             initWithOurVersion:[[S7SubrepoDescription alloc] initWithPath:@"Dependencies/ReaddleLib"
+                                                                       url:@"git@github.com:readdle/readdlelib"
+                                                                  revision:@"1d55eede9471fc9245de5bd85b55102684c8c300"
+                                                                    branch:@"main"]
+             theirVersion:nil]
+        ]
+    ];
+
+    NSString *configFilePath = @"./config";
+
+    if (0 != [originalConfig saveToFileAtPath:configFilePath]) {
+        XCTAssert(NO, @"");
+    }
+
+    S7Config *parsedConfig = [[S7Config alloc] initWithContentsOfFile:configFilePath];
+    XCTAssertNotNil(parsedConfig);
+    XCTAssertEqualObjects(parsedConfig, originalConfig);
+}
+
 - (void)testInvalidConflicts {
     // unterminated conflict
     S7Config *parsedConfig = [[S7Config alloc] initWithContentsString:

--- a/system7/Commands/S7AddCommand.m
+++ b/system7/Commands/S7AddCommand.m
@@ -131,7 +131,7 @@ NS_ASSUME_NONNULL_BEGIN
     BOOL isDirectory = NO;
     if (NO == [[NSFileManager defaultManager] fileExistsAtPath:path isDirectory:&isDirectory]) {
         if (0 == url.length) {
-            NSLog(@"ERROR: failed to add subrepo. Non-empty url expected.");
+            logError("failed to add subrepo. Non-empty url expected.");
             return S7ExitCodeInvalidArgument;
         }
         
@@ -154,7 +154,8 @@ NS_ASSUME_NONNULL_BEGIN
         }
     }
     else if (NO == isDirectory) {
-        NSLog(@"ERROR: failed to add subrepo at path '%@'. File exists and it's not a directory.", path);
+        logError("failed to add subrepo at path '%s'. File exists and it's not a directory.", 
+                 path.fileSystemRepresentation);
         return S7ExitCodeInvalidArgument;
     }
     else {

--- a/system7/Merge Driver/S7ConfigMergeDriver.h
+++ b/system7/Merge Driver/S7ConfigMergeDriver.h
@@ -27,6 +27,7 @@ typedef NS_OPTIONS(uint32_t, S7ConflictResolutionOption) {
 
 @property (nonatomic) S7ConflictResolutionOption (^resolveConflictBlock)(S7SubrepoDescription * _Nullable ourVersion,
                                                                          S7SubrepoDescription * _Nullable theirVersion);
+@property (nonatomic) BOOL (^isTerminalInteractive)(void);
 
 + (S7Config *)mergeOurConfig:(S7Config *)ourLines
                  theirConfig:(S7Config *)theirConfig

--- a/system7/Types/S7Config.m
+++ b/system7/Types/S7Config.m
@@ -134,7 +134,7 @@ NS_ASSUME_NONNULL_BEGIN
 
         S7SubrepoDescription *subrepoDesc = [[S7SubrepoDescription alloc] initWithConfigLine:trimmedLine];
         if (nil == subrepoDesc) {
-            NSLog(@"ERROR: failed to parse config. Invalid line '%@'", line);
+            logError("failed to parse config. Invalid line '%s'", [line cStringUsingEncoding:NSUTF8StringEncoding]);
             return nil;
         }
 
@@ -178,7 +178,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     for (S7SubrepoDescription *subrepoDesc in subrepoDescriptions) {
         if ([subrepoPathsSet containsObject:subrepoDesc.path]) {
-            NSLog(@"ERROR: duplicate path '%@' in config.", subrepoDesc.path);
+            logError("duplicate path '%s' in config.", subrepoDesc.path.fileSystemRepresentation);
             return nil;
         }
 

--- a/system7/Types/S7SubrepoDescriptionConflict.m
+++ b/system7/Types/S7SubrepoDescriptionConflict.m
@@ -75,8 +75,8 @@
              "=======\n"
              "%@\n"
              ">>>>>>> theirs",
-            self.ourVersion,
-            self.theirVersion ];
+            self.ourVersion ? self.ourVersion.stringRepresentation : @"",
+            self.theirVersion ? self.theirVersion.stringRepresentation : @"" ];
 }
 
 


### PR DESCRIPTION
При последнем мерже я столкнулся с тем, что если передать `S7_MERGE_DRIVER_RESPONSE=l`, а при мерже нам попадется конфликт вида `"с одной стороны удалили, с другой поменяли"`, то `s7` падает.

Причина в том, что при рассмотрении `S7_MERGE_DRIVER_RESPONSE` мы не проверяли входит ли она в возможный набор опций для данного вида конфликтов. Слепо верили, что нужно взять `ourVersion`, она оказывалась `nil`, и мы ее радостно сунули в `-[NSArray addObject:]`.

Написал тест на этот случай, и тут выяснилось еще две неприятности:
1. `isatty` прекрасно себе говорит, что Xcode console интерактивна. Поэтому пришлось застабать эту проверку для тестов
2. оказалось, что конфликт `"с одной стороны удалили, с другой поменяли"` некорректно пишется на диск. Для nil-овой стороны он писал `(null)`. Потом при чтении мы ругались на этот `(null)`, и получали `nil` `S7Config`. Написал тест и починил.

Сопутствующе обнаружил четыре места, где юзались NSLog, а не наш logError. Поправил.