### PR TITLE
Added version flag and included HEAD commit hash into version string

### DIFF
--- a/buildme.sh
+++ b/buildme.sh
@@ -29,8 +29,9 @@ xcodebuild_cmd() {
     # these headers are unwanted and may cause module import conflicts  
     unset USER_HEADER_SEARCH_PATHS
     unset HEADER_SEARCH_PATHS
+    S7_OTHER_CFLAGS="-DCOMMIT_HASH=\\\"$(git rev-parse --short HEAD)\\\""
     xcodebuild -target system7 -configuration Release clean
-    xcodebuild -target system7 -configuration Release DSTROOT="$HOME" install
+    xcodebuild -target system7 -configuration Release DSTROOT="$HOME" OTHER_CFLAGS="$S7_OTHER_CFLAGS" install
 }
 
 if ! xcodebuild_cmd

--- a/system7/Commands/S7VersionCommand.m
+++ b/system7/Commands/S7VersionCommand.m
@@ -10,8 +10,9 @@
 
 #import "HelpPager.h"
 
+#ifndef VERSION_NUMBER
 static const char VERSION_NUMBER[] = "1.0";
-static const char VERSION_DATE[] = "2021-02-04";
+#endif
 
 @implementation S7VersionCommand
 
@@ -31,7 +32,11 @@ static const char VERSION_DATE[] = "2021-02-04";
 }
 
 - (int)runWithArguments:(NSArray<NSString *> *)arguments {
-    logInfo("s7 version %s (%s)\n", VERSION_NUMBER, VERSION_DATE);
+    logInfo("s7 version %s", VERSION_NUMBER);
+#ifdef COMMIT_HASH
+    logInfo(" (%s)", COMMIT_HASH);
+#endif
+    logInfo("\n");
     return S7ExitCodeSuccess;
 }
 

--- a/system7/Utils/Utils.h
+++ b/system7/Utils/Utils.h
@@ -31,6 +31,8 @@ int saveUpdatedConfigToMainAndControlFile(S7Config *updatedConfig);
 
 NSString *_Nullable getGlobalGitConfigValue(NSString *key);
 
+BOOL S7ArgumentMatchesFlag(NSString *argument, NSString *longFlag, NSString *shortFlag);
+
 #define S7_REPO_PRECONDITION_CHECK()                    \
     do {                                                \
         const int result = s7RepoPreconditionCheck();   \

--- a/system7/Utils/Utils.m
+++ b/system7/Utils/Utils.m
@@ -403,3 +403,9 @@ int installHook(GitRepository *repo, NSString *hookName, NSString *commandLine, 
 
     return S7ExitCodeSuccess;
 }
+
+BOOL S7ArgumentMatchesFlag(NSString *argument, NSString *longFlag, NSString *shortFlag) {
+    argument = [argument stringByTrimmingCharactersInSet:[NSCharacterSet characterSetWithCharactersInString:@"-"]];
+
+    return [argument isEqualToString:shortFlag] || [argument isEqualToString:longFlag];
+}

--- a/system7/main.m
+++ b/system7/main.m
@@ -236,8 +236,12 @@ int main(int argc, const char * argv[]) {
         [arguments addObject:argument];
     }
 
-    if ([commandName isEqualToString:@"help"]) {
+    if (S7ArgumentMatchesFlag(commandName, @"help", @"h")) {
         return helpCommand(arguments);
+    }
+
+    if (S7ArgumentMatchesFlag(commandName, @"version", @"v")) {
+        return [[S7VersionCommand new] runWithArguments:@[]];
     }
 
     NSString *cwd = [[NSFileManager defaultManager] currentDirectoryPath];


### PR DESCRIPTION
`s7 version` была абсолютно бесполезной, т.к. все значения были зашиты один раз и не менялись.
Добавил хеш HEAD, теперь ясно, с какого состояния она была собрана. Потенциально, это может помочь выявлять баги после апдейтов