### PR TITLE
Fix dolphin added subrepos in status

### DIFF
--- a/system7-tests/integration/test.sh
+++ b/system7-tests/integration/test.sh
@@ -33,7 +33,7 @@ then
     TESTS_TO_RUN=`ls case*.sh`
 fi
 
-if [ ${#TESTS_TO_RUN[@]} -eq 1 ]; then
+if [ ${#CASES_ARRAY[@]} -eq 1 ]; then
     PARALLELIZE=0
 fi
 

--- a/system7-tests/integration/test.sh
+++ b/system7-tests/integration/test.sh
@@ -33,6 +33,7 @@ then
     TESTS_TO_RUN=`ls case*.sh`
 fi
 
+CASES_ARRAY=(${TESTS_TO_RUN[@]})
 if [ ${#CASES_ARRAY[@]} -eq 1 ]; then
     PARALLELIZE=0
 fi

--- a/system7/Commands/S7StatusCommand.m
+++ b/system7/Commands/S7StatusCommand.m
@@ -295,7 +295,7 @@
         if ([NSFileManager.defaultManager fileExistsAtPath:[absoluteSubrepoPath stringByAppendingPathComponent:S7ConfigFileName]]) {
             NSDictionary<NSString *, NSNumber *> *subrepoStatus = nil;
             const int subrepoStatusExitCode = [self repo:subrepoGit calculateStatus:&subrepoStatus];
-            if (0 != subrepoStatusExitCode) {
+            if (S7ExitCodeSuccess != subrepoStatusExitCode) {
                 @synchronized (self) {
                     error = subrepoStatusExitCode;
                 }


### PR DESCRIPTION
Время от времени наблюдал дельфина. `s7 status` выдавал ни с того, ни с сего что "добавился" сабрепозиторий. То FFMpeg, то что-то из сабреп RDPDFKit-а. Запускаешь статус еще раз – уже все чисто. Чудеса.

Можете у себя попробовать в любом rd2 запустить такое:
`for i in {1..100}; do printf "$i "; s7 st -n; done`

Вашему вниманию фикс этого дельфина. По месту поясню суть.
