### PR TITLE
Fix switch between pre-s7 and s7 commits in repo.

### DIFF
--- a/system7-tests/integration/case-switchBetweenPreS7AndS7Commits.sh
+++ b/system7-tests/integration/case-switchBetweenPreS7AndS7Commits.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+git clone github/rd2 pastey/rd2
+
+cd pastey/rd2
+
+COMMIT_WITHOUT_S7="$(git rev-parse HEAD)"
+
+assert s7 init
+assert git add .
+assert git commit -m "\"init s7\""
+
+assert s7 add --stage Dependencies/RDPDFKit '"$S7_ROOT/github/RDPDFKit"'
+
+git commit -m"add pdfkit subrepo"
+
+COMMIT_WITH_S7="$(git rev-parse HEAD)"
+
+# switch back to pre-s7 times
+git checkout "$COMMIT_WITHOUT_S7"
+
+assert test -z "$(git status --porcelain)"
+grep -q "s7" .gitignore
+assert test 1 -eq $?
+assert test ! -f .git/hooks/post-checkout
+
+# to s7 again
+git checkout "$COMMIT_WITH_S7"
+
+assert test -z "$(git status --porcelain)"
+grep -q "s7" .gitignore
+assert test 0 -eq $?
+grep "s7" .git/hooks/post-checkout
+assert test 0 -eq $?
+# bootstrap init must not get stuck on back and forth switches
+grep "init" .git/hooks/post-checkout
+assert test 1 -eq $?
+
+# and to pre-s7 one more time
+git checkout "$COMMIT_WITHOUT_S7"
+
+assert test -z "$(git status --porcelain)"
+grep -q "s7" .gitignore
+assert test 1 -eq $?
+assert test ! -f .git/hooks/post-checkout

--- a/system7-tests/integration/case-switchBetweenPreS7AndS7CommitsMixedWithGitLFS.sh
+++ b/system7-tests/integration/case-switchBetweenPreS7AndS7CommitsMixedWithGitLFS.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+git clone github/rd2 pastey/rd2
+
+cd pastey/rd2
+
+COMMIT_WITHOUT_S7="$(git rev-parse HEAD)"
+
+cat <<EOT > .git/hooks/post-checkout
+#!/bin/sh
+echo "Git LFS was here"
+EOT
+
+assert s7 init
+assert git add .
+assert git commit -m "\"init s7\""
+
+assert s7 add --stage Dependencies/RDPDFKit '"$S7_ROOT/github/RDPDFKit"'
+
+git commit -m"add pdfkit subrepo"
+
+COMMIT_WITH_S7="$(git rev-parse HEAD)"
+
+# switch back to pre-s7 times
+git checkout "$COMMIT_WITHOUT_S7"
+
+assert test -z "$(git status --porcelain)"
+grep -q "s7" .gitignore
+assert test 1 -eq $?
+grep -q -i "lfs" .git/hooks/post-checkout
+assert test 0 -eq $?
+grep "s7" .git/hooks/post-checkout
+assert test 1 -eq $?
+
+# to s7 again
+git checkout "$COMMIT_WITH_S7"
+
+assert test -z "$(git status --porcelain)"
+grep -q "s7" .gitignore
+assert test 0 -eq $?
+grep -q -i "lfs" .git/hooks/post-checkout
+assert test 0 -eq $?
+grep "s7" .git/hooks/post-checkout
+assert test 0 -eq $?
+# bootstrap init must not get stuck on back and forth switches
+grep "init" .git/hooks/post-checkout
+assert test 1 -eq $?
+
+# and to pre-s7 one more time
+git checkout "$COMMIT_WITHOUT_S7"
+
+assert test -z "$(git status --porcelain)"
+grep -q "s7" .gitignore
+assert test 1 -eq $?
+grep -q -i "lfs" .git/hooks/post-checkout
+assert test 0 -eq $?
+grep "s7" .git/hooks/post-checkout
+assert test 1 -eq $?

--- a/system7-tests/integration/test.sh
+++ b/system7-tests/integration/test.sh
@@ -98,15 +98,25 @@ setupAndRunCase() {
 
     if [ 1 -eq $PARALLELIZE ]; then
         S7_ROOT="$TEST_ROOT" sh -x "$SCRIPT_SOURCE_DIR/$CASE" >"$TEST_ROOT/log.txt" 2>&1
+
+        if [ -f "$TEST_ROOT/FAIL" ]; then
+            printf "${red}x${normal}"
+        else
+            printf "${green}v${normal}"
+        fi
     else
+        echo
+        echo "$CASE"
+        echo "============="
         S7_ROOT="$TEST_ROOT" sh -x "$SCRIPT_SOURCE_DIR/$CASE" 2>&1
+        echo
+        if [ -f "$TEST_ROOT/FAIL" ]; then
+            printf "❌\n"
+        else
+            printf "✅\n"
+        fi
     fi
 
-    if [ -f "$TEST_ROOT/FAIL" ]; then
-        printf "${red}x${normal}"
-    else
-        printf "${green}v${normal}"
-    fi
 }
 
 for CASE in $TESTS_TO_RUN; do

--- a/system7/Hooks/S7PostCheckoutHook.m
+++ b/system7/Hooks/S7PostCheckoutHook.m
@@ -11,6 +11,7 @@
 #import "S7Diff.h"
 #import "S7Utils.h"
 #import "S7InitCommand.h"
+#import "S7DeinitCommand.h"
 #import "S7BootstrapCommand.h"
 #import "S7Options.h"
 #import "S7Logging.h"
@@ -132,14 +133,12 @@ static void (^_warnAboutDetachingCommitsHook)(NSString *topRevision, int numberO
             return S7ExitCodeFileOperationFailed;
         }
     }
-    else if ([NSFileManager.defaultManager fileExistsAtPath:controlFileAbsolutePath]) {
-        NSError *error = nil;
-        if (NO == [NSFileManager.defaultManager removeItemAtPath:controlFileAbsolutePath error:&error]) {
-            logError("failed to remove %s. Error: %s\n",
-                     S7ControlFileName.fileSystemRepresentation,
-                     [[error description] cStringUsingEncoding:NSUTF8StringEncoding]);
-            return S7ExitCodeFileOperationFailed;
-        }
+    else {
+        // switch to a pre-s7 state. Let's call deinit.
+        // It will remove all untracked s7 system files, s7 hooks, merge driver, etc.
+        //
+        S7DeinitCommand *command = [S7DeinitCommand new];
+        return [command runWithArguments:@[]];
     }
 
     return S7ExitCodeSuccess;

--- a/system7/git/Git.m
+++ b/system7/git/Git.m
@@ -599,7 +599,7 @@ static void (^_testRepoConfigureOnInitBlock)(GitRepository *);
     //     they have an easier ways than injections
     //  2. anyway 'command' is then split into arguments and passed to git as an array, so git would most likely
     //     not accept these arguments; unless the user is super smart to build some fancy git command that allows
-    //     exectuting different git commands (see point #1)
+    //     executing different git commands (see point #1)
     //
     return [self runGitCommand:[NSString stringWithFormat:@"checkout -B %@ %@", branchName, revisions]
                   stdOutOutput:NULL


### PR DESCRIPTION
STR:
1. s7 repo
2. switch to a commit before s7
3. switch to a commit with s7
4. switch to a commit before s7

As the result:
- at step 2 repo kept almost all s7 system files (except .s7control). And all s7 hooks!
- at step 3 s7 bootstrap added 's7 init' to the post-checkout (in addition to the actual post-checkout)
- at step 4 we got a bonus call of 's7 init' and the state we couldn't escape without a call to 's7 deinit'

При черговому мержі стикнувся із залипанням в одній з сабреп. При мержі ми перемикалися зі стану із саб-сабрепою, без саб-сабрепи, і знову із саб-сабрепою. Я вже не раз таке бачив, але тут в мене з'явився чіткий сценарій як це відтворити.