### PR TITLE
EXP-15601: Updated error log to include NSError for S7IniConfig

### DIFF
--- a/system7/Ini Parser/S7IniConfig.m
+++ b/system7/Ini Parser/S7IniConfig.m
@@ -40,7 +40,15 @@
                                                              encoding:NSUTF8StringEncoding
                                                                 error:&error];
     if (nil == fileContents || error) {
-        logError("failed to load config at path '%s'. Failed to read string content.", filePath.fileSystemRepresentation);
+        NSString const* errorString = @"Failed to read string content";
+
+        if (error) {
+            errorString = [NSString stringWithFormat:@"Failed with error: %@", error];
+        }
+
+        logError("failed to load config at path '%s'. '%s'.",
+                 filePath.fileSystemRepresentation,
+                 [errorString UTF8String]);
         return nil;
     }
 


### PR DESCRIPTION
__Ticket link__

[EXP-15575](https://readdle-j.atlassian.net/browse/EXP-15575)

__PR description__

- What is the context for this PR?

Updated `S7IniConfig.m + (instancetype)configWithContentsOfFile:(NSString *)filePath` implementation to include NSError form `initWithContentsOfFile` error property or keep "Failed to read string content" error message if we read no content without any error.

- Why did you take the approach you did?

__Screenshot / Videos__

If it would be useful, please, include screenshots, animated GIFs or screencasts of changes in action

__PR submission checklist__

- [x] PR name contains Jira ticket number
- [x] PR have correct target branch
- [ ] .s7substat has correct subrepos revisions
- [x] Common ([Obj-C](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/3802038524/Common+Objective-C+Code+Style+Guide+for+Docs+PE+iOS+Mac+Teams) / [Swift](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4662394906/Common+Swift+Code+Style+Guide+for+Docs+PE+iOS+Mac+Teams)) and your team's coding conventions and style guidelines are followed
- [ ] Unit tests to cover the critical parts of the code are written
- [ ] Relevant documentation updated / added if needed
- [x] Self-reviewed using the [self-review checklist](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4645978135) prior to submitting a PR
- [x] All recommendations from the [How to create Pull Request](https://readdle-c.atlassian.net/wiki/spaces/DOC/pages/4568416271/How+to+create+Pull+Request+PR) document are followed


[EXP-15575]: https://readdle-j.atlassian.net/browse/EXP-15575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ